### PR TITLE
Add MUXSDKStats query parameter filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/xcshareddata/*
 **/Pods/*
 **/*.xcworkspace/*
+.DS_Store

--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.h
@@ -49,6 +49,8 @@ typedef NS_ENUM(NSUInteger, MUXSDKPlayerState) {
     long long _lastTransferredBytes;
 }
 
+@property (copy) NSString* videoSourceUrlOverride;
+
 - (id)initWithName:(NSString *)name andSoftware:(NSString *)software;
 - (void)attachAVPlayer:(AVPlayer *)player;
 - (void)detachAVPlayer;

--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -1,5 +1,5 @@
 #import "MUXSDKPlayerBinding.h"
-
+#import "MUXSDKStats.h"
 #import <Foundation/Foundation.h>
 
 @import CoreMedia;
@@ -263,8 +263,8 @@ static void *MUXSDKAVPlayerItemStatusObservationContext = &MUXSDKAVPlayerStatusO
     AVAsset *currentPlayerAsset = _player.currentItem.asset;
     if ([currentPlayerAsset isKindOfClass:AVURLAsset.class]) {
         AVURLAsset *urlAsset = (AVURLAsset *)currentPlayerAsset;
-        NSString * urlString = [[urlAsset URL] absoluteString];
-        if (!_videoURL || [_videoURL isEqualToString:urlString]) {
+        NSString * urlString = [MUXSDKStats filteredStringFromURL:[urlAsset URL]];
+        if (!_videoURL || ![_videoURL isEqualToString:urlString]) {
             _videoURL = urlString;
             videoDataUpdated = YES;
         }

--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -1,5 +1,4 @@
 #import "MUXSDKPlayerBinding.h"
-#import "MUXSDKStats.h"
 #import <Foundation/Foundation.h>
 
 @import CoreMedia;

--- a/MUXSDKStats/MUXSDKStats/MUXSDKStats.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKStats.h
@@ -37,14 +37,6 @@ FOUNDATION_EXPORT
 - (_Null_unspecified instancetype)init NS_UNAVAILABLE;
 + (_Null_unspecified instancetype)new NS_UNAVAILABLE;
 
-/*
- Filter query parameters from playback URLs prior to reporting to Mux.
- This has no impact on playback, but will affect the data sent for analytics.
- */
-+ (void)addQueryParamFilter:(nonnull NSString*)paramName;
-+ (void)removeQueryParamFilter:(nonnull NSString*)paramName;
-+ (nonnull NSString*)filteredStringFromURL:(nonnull NSURL*)url;
-
 /*!
  @method      monitorAVPlayerViewController:withPlayerName:playerData:videoData:
  @abstract    Starts to monitor a given AVPlayerViewController.
@@ -55,7 +47,16 @@ FOUNDATION_EXPORT
  @return      an instance of MUXSDKAVPlayerLayerBinding or null
  @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
  */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player withPlayerName:(nonnull NSString *)name playerData:(nonnull MUXSDKCustomerPlayerData *)playerData videoData:(nullable MUXSDKCustomerVideoData *)videoData;
++ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
+                                                 withPlayerName:(nonnull NSString *)name
+                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
+                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData;
+
++ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
+                                                 withPlayerName:(nonnull NSString *)name
+                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
+                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData
+                                                 videoSourceUrl:(nullable NSString*)videoSourceUrl;
 
 /*!
  @method      updateAVPlayerViewController:withPlayerName

--- a/MUXSDKStats/MUXSDKStats/MUXSDKStats.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKStats.h
@@ -37,6 +37,14 @@ FOUNDATION_EXPORT
 - (_Null_unspecified instancetype)init NS_UNAVAILABLE;
 + (_Null_unspecified instancetype)new NS_UNAVAILABLE;
 
+/*
+ Filter query parameters from playback URLs prior to reporting to Mux.
+ This has no impact on playback, but will affect the data sent for analytics.
+ */
++ (void)addQueryParamFilter:(nonnull NSString*)paramName;
++ (void)removeQueryParamFilter:(nonnull NSString*)paramName;
++ (nonnull NSString*)filteredStringFromURL:(nonnull NSURL*)url;
+
 /*!
  @method      monitorAVPlayerViewController:withPlayerName:playerData:videoData:
  @abstract    Starts to monitor a given AVPlayerViewController.

--- a/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -110,4 +110,26 @@
     [MUXSDKStats destroyPlayer:playName];
 }
 
+- (void)testQueryParamFilter {
+    [MUXSDKStats addQueryParamFilter:@"superSecret"];
+    NSURL* src = [NSURL URLWithString:@"https://example.com/master.m3u8?trivial=foo&superSecret=bar"];
+    NSString* dest = [MUXSDKStats filteredStringFromURL:src];
+    NSURLComponents* destComponents = [NSURLComponents componentsWithString:dest];
+    NSArray<NSURLQueryItem*>* destQueryItems = destComponents.queryItems;
+    NSURLQueryItem* secretItem = nil;
+    NSURLQueryItem* lessSecretItem = nil;
+    for (NSURLQueryItem* queryItem in destQueryItems) {
+        if ([queryItem.name isEqualToString:@"superSecret"]) {
+            secretItem = queryItem;
+        }
+        if ([queryItem.name isEqualToString:@"trivial"]) {
+            lessSecretItem = queryItem;
+        }
+    }
+    XCTAssertNotNil(secretItem);
+    XCTAssertNotNil(lessSecretItem);
+    XCTAssertFalse([secretItem.value isEqualToString:@"bar"]);
+    XCTAssertTrue([lessSecretItem.value isEqualToString:@"foo"]);
+}
+
 @end

--- a/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -110,26 +110,4 @@
     [MUXSDKStats destroyPlayer:playName];
 }
 
-- (void)testQueryParamFilter {
-    [MUXSDKStats addQueryParamFilter:@"superSecret"];
-    NSURL* src = [NSURL URLWithString:@"https://example.com/master.m3u8?trivial=foo&superSecret=bar"];
-    NSString* dest = [MUXSDKStats filteredStringFromURL:src];
-    NSURLComponents* destComponents = [NSURLComponents componentsWithString:dest];
-    NSArray<NSURLQueryItem*>* destQueryItems = destComponents.queryItems;
-    NSURLQueryItem* secretItem = nil;
-    NSURLQueryItem* lessSecretItem = nil;
-    for (NSURLQueryItem* queryItem in destQueryItems) {
-        if ([queryItem.name isEqualToString:@"superSecret"]) {
-            secretItem = queryItem;
-        }
-        if ([queryItem.name isEqualToString:@"trivial"]) {
-            lessSecretItem = queryItem;
-        }
-    }
-    XCTAssertNotNil(secretItem);
-    XCTAssertNotNil(lessSecretItem);
-    XCTAssertFalse([secretItem.value isEqualToString:@"bar"]);
-    XCTAssertTrue([lessSecretItem.value isEqualToString:@"foo"]);
-}
-
 @end


### PR DESCRIPTION
This change proposes a method to redact (prior known) components of a query parameter that would not be appropriate to report to an analytics service, such as access tokens to a playback URL, PII, or any derivative.

For example, if a playback URL scheme included an `accessToken` query parameter and this field needed to be redacted from analytics, integrators may invoke:

```objc
[MUXSDKStats addQueryParamFilter:@"accessToken"];
```

Prior to attaching a video player monitor.