### PR TITLE
Adds an automated test for DemoApp that launches the app and plays one video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 **/xcuserdata/*
-**/xcshareddata/*
 **/Pods/*
 **/*.xcworkspace/*
 *.DS_Store

--- a/apps/DemoApp/DemoApp.xcodeproj/project.pbxproj
+++ b/apps/DemoApp/DemoApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0218F2562548B9A3009DF1FF /* DemoAppUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 0218F2552548B9A3009DF1FF /* DemoAppUITests.m */; };
 		D8B34411304E49CD375FE160 /* Pods_DemoApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E7D36B38BD027A35DC011F82 /* Pods_DemoApp.framework */; };
 		F444D43D1DDB8EBF00FE804F /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F444D43C1DDB8EBF00FE804F /* main.m */; };
 		F444D4401DDB8EBF00FE804F /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F444D43F1DDB8EBF00FE804F /* AppDelegate.m */; };
@@ -16,7 +17,20 @@
 		F444D44B1DDB8EBF00FE804F /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F444D4491DDB8EBF00FE804F /* LaunchScreen.storyboard */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		0218F2582548B9A3009DF1FF /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F444D4301DDB8EBF00FE804F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F444D4371DDB8EBF00FE804F;
+			remoteInfo = DemoApp;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
+		0218F2532548B9A3009DF1FF /* DemoAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DemoAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0218F2552548B9A3009DF1FF /* DemoAppUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DemoAppUITests.m; sourceTree = "<group>"; };
+		0218F2572548B9A3009DF1FF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1CC90219AADA39A22090EBB5 /* Pods-DemoApp.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoApp.debug.xcconfig"; path = "Target Support Files/Pods-DemoApp/Pods-DemoApp.debug.xcconfig"; sourceTree = "<group>"; };
 		43D2FCEDE6A95504D21CE9C2 /* Pods-DemoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DemoApp.release.xcconfig"; path = "Target Support Files/Pods-DemoApp/Pods-DemoApp.release.xcconfig"; sourceTree = "<group>"; };
 		E7D36B38BD027A35DC011F82 /* Pods_DemoApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DemoApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -34,6 +48,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0218F2502548B9A3009DF1FF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F444D4351DDB8EBF00FE804F /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -45,6 +66,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0218F2542548B9A3009DF1FF /* DemoAppUITests */ = {
+			isa = PBXGroup;
+			children = (
+				0218F2552548B9A3009DF1FF /* DemoAppUITests.m */,
+				0218F2572548B9A3009DF1FF /* Info.plist */,
+			);
+			path = DemoAppUITests;
+			sourceTree = "<group>";
+		};
 		D4FC223FD5BBFE596F4A0787 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -58,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				F444D43A1DDB8EBF00FE804F /* DemoApp */,
+				0218F2542548B9A3009DF1FF /* DemoAppUITests */,
 				F444D4561DDBB14C00FE804F /* Frameworks */,
 				F444D4391DDB8EBF00FE804F /* Products */,
 				D4FC223FD5BBFE596F4A0787 /* Pods */,
@@ -68,6 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				F444D4381DDB8EBF00FE804F /* DemoApp.app */,
+				0218F2532548B9A3009DF1FF /* DemoAppUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -108,6 +140,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0218F2522548B9A3009DF1FF /* DemoAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0218F25C2548B9A3009DF1FF /* Build configuration list for PBXNativeTarget "DemoAppUITests" */;
+			buildPhases = (
+				0218F24F2548B9A3009DF1FF /* Sources */,
+				0218F2502548B9A3009DF1FF /* Frameworks */,
+				0218F2512548B9A3009DF1FF /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0218F2592548B9A3009DF1FF /* PBXTargetDependency */,
+			);
+			name = DemoAppUITests;
+			productName = DemoAppUITests;
+			productReference = 0218F2532548B9A3009DF1FF /* DemoAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		F444D4371DDB8EBF00FE804F /* DemoApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F444D44F1DDB8EBF00FE804F /* Build configuration list for PBXNativeTarget "DemoApp" */;
@@ -136,6 +186,12 @@
 				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Mux, Inc.";
 				TargetAttributes = {
+					0218F2522548B9A3009DF1FF = {
+						CreatedOnToolsVersion = 12.0;
+						DevelopmentTeam = GFDDVAVUVC;
+						ProvisioningStyle = Automatic;
+						TestTargetID = F444D4371DDB8EBF00FE804F;
+					};
 					F444D4371DDB8EBF00FE804F = {
 						CreatedOnToolsVersion = 8.0;
 						DevelopmentTeam = CX6AHWLHM6;
@@ -158,11 +214,19 @@
 			projectRoot = "";
 			targets = (
 				F444D4371DDB8EBF00FE804F /* DemoApp */,
+				0218F2522548B9A3009DF1FF /* DemoAppUITests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0218F2512548B9A3009DF1FF /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F444D4361DDB8EBF00FE804F /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -185,7 +249,6 @@
 				"${PODS_ROOT}/Target Support Files/Pods-DemoApp/Pods-DemoApp-frameworks.sh",
 				"${PODS_ROOT}/GoogleAds-IMA-iOS-SDK/GoogleInteractiveMediaAds.framework",
 				"${PODS_ROOT}/../../../Frameworks/iOS/fat/MUXSDKStats.framework",
-				"${PODS_ROOT}/../../../Frameworks/iOS/fat/MUXSDKStats.framework.dSYM",
 				"${PODS_ROOT}/Mux-Stats-Core/Frameworks/iOS/fat/MuxCore.framework",
 				"${BUILT_PRODUCTS_DIR}/Mux-Stats-Google-IMA/Mux_Stats_Google_IMA.framework",
 			);
@@ -193,7 +256,6 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleInteractiveMediaAds.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MUXSDKStats.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/MUXSDKStats.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MuxCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Mux_Stats_Google_IMA.framework",
 			);
@@ -227,6 +289,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0218F24F2548B9A3009DF1FF /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0218F2562548B9A3009DF1FF /* DemoAppUITests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F444D4341DDB8EBF00FE804F /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -238,6 +308,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		0218F2592548B9A3009DF1FF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F444D4371DDB8EBF00FE804F /* DemoApp */;
+			targetProxy = 0218F2582548B9A3009DF1FF /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		F444D4441DDB8EBF00FE804F /* Main.storyboard */ = {
@@ -259,6 +337,69 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		0218F25A2548B9A3009DF1FF /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GFDDVAVUVC;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = DemoAppUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nidhikulkarni.DemoAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DemoApp;
+			};
+			name = Debug;
+		};
+		0218F25B2548B9A3009DF1FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = GFDDVAVUVC;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = DemoAppUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nidhikulkarni.DemoAppUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = DemoApp;
+			};
+			name = Release;
+		};
 		F444D44D1DDB8EBF00FE804F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -388,6 +529,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0218F25C2548B9A3009DF1FF /* Build configuration list for PBXNativeTarget "DemoAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0218F25A2548B9A3009DF1FF /* Debug */,
+				0218F25B2548B9A3009DF1FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F444D4331DDB8EBF00FE804F /* Build configuration list for PBXProject "DemoApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/apps/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
+++ b/apps/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoApp.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F444D4371DDB8EBF00FE804F"
+               BuildableName = "DemoApp.app"
+               BlueprintName = "DemoApp"
+               ReferencedContainer = "container:DemoApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "02F1111324D22B1E00560B40"
+               BuildableName = "DemoAppUITests.xctest"
+               BlueprintName = "DemoAppUITests"
+               ReferencedContainer = "container:DemoApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F444D4371DDB8EBF00FE804F"
+            BuildableName = "DemoApp.app"
+            BlueprintName = "DemoApp"
+            ReferencedContainer = "container:DemoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F444D4371DDB8EBF00FE804F"
+            BuildableName = "DemoApp.app"
+            BlueprintName = "DemoApp"
+            ReferencedContainer = "container:DemoApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoAppUITests.xcscheme
+++ b/apps/DemoApp/DemoApp.xcodeproj/xcshareddata/xcschemes/DemoAppUITests.xcscheme
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1200"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0218F2522548B9A3009DF1FF"
+               BuildableName = "DemoAppUITests.xctest"
+               BlueprintName = "DemoAppUITests"
+               ReferencedContainer = "container:DemoApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0218F2522548B9A3009DF1FF"
+               BuildableName = "DemoAppUITests.xctest"
+               BlueprintName = "DemoAppUITests"
+               ReferencedContainer = "container:DemoApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/apps/DemoApp/DemoApp/ViewController.m
+++ b/apps/DemoApp/DemoApp/ViewController.m
@@ -137,7 +137,11 @@ static NSString *DEMO_PLAYER_NAME = @"demoplayer";
     _avplayerController.player = _avplayer;
 
     // TODO: Add your property key!
-    MUXSDKCustomerPlayerData *playerData = [[MUXSDKCustomerPlayerData alloc] initWithPropertyKey:@"YOUR_ENV_KEY_HERE"];
+    NSString *envKey = [NSProcessInfo.processInfo.environment objectForKey:@"ENV_KEY"];
+    if(envKey == nil) {
+        envKey = @"YOUR_ENV_KEY_HERE";
+    }
+    MUXSDKCustomerPlayerData *playerData = [[MUXSDKCustomerPlayerData alloc] initWithPropertyKey:envKey];
     MUXSDKCustomerVideoData *videoData = [MUXSDKCustomerVideoData new];
     videoData.videoTitle = @"Big Buck Bunny";
     videoData.videoId = @"bigbuckbunny";

--- a/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
+++ b/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
@@ -1,0 +1,40 @@
+//
+//  DemoAppUITests.m
+//  DemoAppUITests
+//
+//  Created by Nidhi Kulkarni on 10/27/20.
+//  Copyright © 2020 Mux, Inc. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface DemoAppUITests : XCTestCase
+
+@end
+
+@implementation DemoAppUITests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    self.continueAfterFailure = NO;
+    
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample {
+    // UI tests must launch the application that they test.
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    [app launch];
+    XCTestExpectation *exp = [[XCTestExpectation alloc] initWithDescription:@"Just wait for 10 seconds."];
+    XCTWaiterResult result = [XCTWaiter waitForExpectations:@[exp] timeout:10.0];
+    // Use recording to get started writing UI tests.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+@end

--- a/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
+++ b/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
@@ -27,14 +27,15 @@
     // Put teardown code here. This method is called after the invocation of each test method in the class.
 }
 
-- (void)testExample {
-    // UI tests must launch the application that they test.
+- (void)testPlayVideo {
     XCUIApplication *app = [[XCUIApplication alloc] init];
+    [app setLaunchEnvironment:@{@"ENV_KEY": @"is1368012c267a34rk0rhhr4u"}];
     [app launch];
-    XCTestExpectation *exp = [[XCTestExpectation alloc] initWithDescription:@"Just wait for 10 seconds."];
-    XCTWaiterResult result = [XCTWaiter waitForExpectations:@[exp] timeout:10.0];
-    // Use recording to get started writing UI tests.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
+    XCTestExpectation *exp = [[XCTestExpectation alloc] initWithDescription:@"Just wait for 20 seconds."];
+    XCTWaiterResult result = [XCTWaiter waitForExpectations:@[exp] timeout:20.0];
+    if(result != XCTWaiterResultTimedOut) {
+        XCTFail(@"Interrupted while playing video.");
+    }
 }
 
 @end

--- a/apps/DemoApp/DemoAppUITests/Info.plist
+++ b/apps/DemoApp/DemoAppUITests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/apps/DemoApp/run-tests.sh
+++ b/apps/DemoApp/run-tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-buildkite-agent artifact download "Frameworks/**/*" "Frameworks" --step "buildkite.sh"
+buildkite-agent artifact download "MUXSDKStats.framework.zip" . --step "buildkite.sh"
+unzip MUXSDKStats.framework.zip -d Frameworks
 cd apps/DemoApp
 pod deintegrate && pod install
 xcodebuild -workspace DemoApp.xcworkspace \

--- a/apps/DemoApp/run-tests.sh
+++ b/apps/DemoApp/run-tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-buildkite-agent artifact download "Frameworks/**/*" "../../Frameworks" --step "buildkite.sh"
+buildkite-agent artifact download "Frameworks/**/*" "Frameworks" --step "buildkite.sh"
+cd apps/DemoApp
 pod deintegrate && pod install
 xcodebuild -workspace DemoApp.xcworkspace \
            -scheme "DemoApp" \

--- a/apps/DemoApp/run-tests.sh
+++ b/apps/DemoApp/run-tests.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 buildkite-agent artifact download "MUXSDKStats.framework.zip" . --step "buildkite.sh"
-unzip MUXSDKStats.framework.zip -d Frameworks
+unzip MUXSDKStats.framework.zip
 cd apps/DemoApp
 pod deintegrate && pod install
 xcodebuild -workspace DemoApp.xcworkspace \

--- a/apps/DemoApp/run-tests.sh
+++ b/apps/DemoApp/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+buildkite-agent artifact download "Frameworks/**/*" "../../Frameworks" --step "buildkite.sh"
+pod deintegrate && pod install
+xcodebuild -workspace DemoApp.xcworkspace \
+           -scheme "DemoApp" \
+           -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.1' \
+           test

--- a/apps/DemoApp/run-tests.sh
+++ b/apps/DemoApp/run-tests.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# Delete the old stuff
+rm -Rf Frameworks
+
 buildkite-agent artifact download "MUXSDKStats.framework.zip" . --step "buildkite.sh"
 unzip MUXSDKStats.framework.zip
 cd apps/DemoApp


### PR DESCRIPTION
## Zube

https://zube.io/muxinc/mux/c/13153

## Overview

* Adds a new UI test target for the DemoApp. Adds a simple test case that launches the app and plays one video. 
* Updates the buildkite script to install Mux-Stats-AVPlayer SDK built from a previous step and run the tests. 

## Example Run

```
Testing started
--
  | 2020-10-27 17:06:17.313 xcodebuild[33482:3381246]  IDETestOperationsObserverDebug: Writing diagnostic log for test session to:
  | /Users/administrator/Library/Developer/Xcode/DerivedData/DemoApp-eknlxvcjybxdqcchzaxhlhuxpjzn/Logs/Test/Test-DemoApp-2020.10.27_17-06-10--0700.xcresult/Staging/1_Test/Diagnostics/DemoAppUITests-7E7F6387-BFF9-4AAF-90B5-92E05A3D1F12/DemoAppUITests-C4C34BAD-489D-41C5-BF50-135205AAF14B/Session-DemoAppUITests-2020-10-27_170617-NKL8o5.log
  | 2020-10-27 17:06:17.313 xcodebuild[33482:3381189] [MT] IDETestOperationsObserverDebug: (C59B3B87-48E2-45AA-90F2-A8391AD44335) Beginning test session DemoAppUITests-C59B3B87-48E2-45AA-90F2-A8391AD44335 at 2020-10-27 17:06:17.314 with Xcode 12A7403 on target <DVTiPhoneSimulator: 0x7fc924e4c850> {
  | SimDevice: iPhone 11 (486E7844-495A-48DB-9BD0-2533419B14B7, iOS 14.1, Shutdown)
  | } (14.1 (18A8394))
  | 2020-10-27 17:06:34.921 xcodebuild[33482:3381189] [MT] IDETestOperationsObserverDebug: (C59B3B87-48E2-45AA-90F2-A8391AD44335) Finished requesting crash reports. Continuing with testing.
  | 2020-10-27 17:06:40.723635-0700 DemoAppUITests-Runner[33804:3389885] Running tests...
  | Test Suite 'All tests' started at 2020-10-27 17:06:42.092
  | Test Suite 'DemoAppUITests.xctest' started at 2020-10-27 17:06:42.095
  | Test Suite 'DemoAppUITests' started at 2020-10-27 17:06:42.096
  | Test Case '-[DemoAppUITests testPlayVideo]' started.
  | t =     0.00s Start Test at 2020-10-27 17:06:42.099
  | t =     0.14s Set Up
  | t =     0.18s Open com.mux.stats.ios.DemoApp22
  | t =     0.31s     Launch com.mux.stats.ios.DemoApp22
  | t =     2.60s         Wait for accessibility to load
  | t =     2.80s         Setting up automation session
  | t =     2.90s         Wait for com.mux.stats.ios.DemoApp22 to idle
  | t =    24.68s Tear Down
  | Test Case '-[DemoAppUITests testPlayVideo]' passed (24.889 seconds).
  | Test Suite 'DemoAppUITests' passed at 2020-10-27 17:07:06.987.
  | Executed 1 test, with 0 failures (0 unexpected) in 24.889 (24.891) seconds
  | Test Suite 'DemoAppUITests.xctest' passed at 2020-10-27 17:07:06.988.
  | Executed 1 test, with 0 failures (0 unexpected) in 24.889 (24.893) seconds
  | Test Suite 'All tests' passed at 2020-10-27 17:07:06.990.
  | Executed 1 test, with 0 failures (0 unexpected) in 24.889 (24.898) seconds
  | 2020-10-27 17:07:07.305 xcodebuild[33482:3381189] [MT] IDETestOperationsObserverDebug: 50.002 elapsed -- Testing started completed.
  | 2020-10-27 17:07:07.305 xcodebuild[33482:3381189] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
  | 2020-10-27 17:07:07.306 xcodebuild[33482:3381189] [MT] IDETestOperationsObserverDebug: 50.002 sec, +50.002 sec -- end
  |  
  | Test session results, code coverage, and logs:
  | /Users/administrator/Library/Developer/Xcode/DerivedData/DemoApp-eknlxvcjybxdqcchzaxhlhuxpjzn/Logs/Test/Test-DemoApp-2020.10.27_17-06-10--0700.xcresult
  |  
  | ** TEST SUCCEEDED **


```

![Screen Shot 2020-10-27 at 8 09 47 PM](https://user-images.githubusercontent.com/1444681/97375164-74457b80-1890-11eb-84c8-b44815a94e8f.png)



A view from the test:
https://dashboard.mux.com/environments/av8gn4/views/NPn9dzeU6qqyVrHrBoc8KNc1x2sKj6zmGRne

The Build machine is located near Las Vegas, which we detect :) 
![Screen Shot 2020-10-27 at 8 15 59 PM](https://user-images.githubusercontent.com/1444681/97375489-50cf0080-1891-11eb-8096-b98a3260ca56.png)

![Screen Shot 2020-10-27 at 8 16 52 PM](https://user-images.githubusercontent.com/1444681/97375501-5fb5b300-1891-11eb-9afe-f1f2cfe621c8.png)

