### PR TITLE
Allow disabling built-in videochanges

### DIFF
--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.h
@@ -87,6 +87,7 @@ typedef NS_ENUM(NSUInteger, MUXSDKViewOrientation) {
 - (float)getCurrentPlayheadTimeMs;
 - (void)dispatchRenditionChange;
 - (BOOL)setAutomaticErrorTracking:(BOOL)automaticErrorTracking;
+- (BOOL)setAutomaticVideoChange:(BOOL)automaticVideoChange;
 - (void)dispatchError:(NSString *)code withMessage:(NSString *)message;
 
 @end

--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -58,7 +58,6 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
 }
 
 - (BOOL)setAutomaticVideoChange:(BOOL)automaticVideoChange {
-    NSLog(@"MUXSDK-JAMES - YEAH ROY!");
     _automaticVideoChange = automaticVideoChange;
     return _automaticVideoChange;
 }

--- a/MUXSDKStats/MUXSDKStats/MUXSDKStats.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKStats.h
@@ -178,6 +178,17 @@ FOUNDATION_EXPORT
  @discussion  Use this method to signal that the player is now playing a new video. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should include all desired keys, not just those keys that are specific to this video. If the name of the player provided was not previously initialized, an exception will be raised.
 
  */
++ (void)setAutomaticVideoChange:(nonnull NSString *)name enabled:(nullable Boolean *)enabled;
+
+/*!
+ @method      setAutomaticVideoChange:forPlayer:enabled
+ @abstract    Allows default videochange functionality to be disabled.
+ @param       name The name of the player to update
+ @param       enabled Whether to enabled or disable the automatic videochange functionality
+ @discussion  Use this method to disable built in videochange calls when using AVQueuePlayer.. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should set the enabled value to false. The default setting is true. If the name of the player provided was not previously initialized, an exception will be raised.
+
+ */
+
 + (void)videoChangeForPlayer:(nonnull NSString *)name withVideoData:(nullable MUXSDKCustomerVideoData *)videoData;
 
 /*!

--- a/MUXSDKStats/MUXSDKStats/MUXSDKStats.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKStats.m
@@ -373,6 +373,13 @@ static MUXSDKCustomerViewDataStore *_customerViewDataStore;
     }
 }
 
++ (void)setAutomaticVideoChange:(NSString *)name  enabled:(nullable Boolean *)enabled {
+    MUXSDKPlayerBinding *player = [_viewControllers valueForKey:name];
+    if(player) {
+        [player setAutomaticVideoChange:enabled];
+    }
+}
+
 #pragma mark Update Customer Data
 
 + (void)updateCustomerDataForPlayer:(nonnull NSString *)name withPlayerData:(nullable MUXSDKCustomerPlayerData *)playerData withVideoData:(nullable MUXSDKCustomerVideoData *)videoData {


### PR DESCRIPTION
Allows customers to override any default videochanges we call automatically in the SDK. By default, we want to leave this enabled.

This helps in a case where a customer forces a reload of the same video to the player (e.g, when transition from the background to the foreground. When using AVQueuePlayer, this causes Mux to emit a videochange by default. With this PR, we now have `[MUXSDKStats setAutomaticVideoChange:DEMO_PLAYER_NAME enabled:false];` as an option which can be set after the SDK is initialised, to stop that from happening and keep the same video tracked in a single view.

(XCFramework excluded for now for readability)