### PR TITLE
Erase simulators before tests run

### DIFF
--- a/apps/DemoApp/run-tests.sh
+++ b/apps/DemoApp/run-tests.sh
@@ -3,7 +3,9 @@ set -euo pipefail
 
 # Delete the old stuff
 rm -Rf XCFramework
-
+# reset simulators
+xcrun simctl shutdown all
+xcrun simctl erase all
 buildkite-agent artifact download "MUXSDKStats.xcframework.zip" . --step ".buildkite/build.sh"
 unzip MUXSDKStats.xcframework.zip
 cd apps/DemoApp

--- a/apps/DemoApp/run-tests.sh
+++ b/apps/DemoApp/run-tests.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Delete the old stuff
 rm -Rf XCFramework
 # reset simulators
-xcrun simctl shutdown all
-xcrun simctl erase all
+xcrun -v simctl shutdown all
+xcrun -v simctl erase all
 buildkite-agent artifact download "MUXSDKStats.xcframework.zip" . --step ".buildkite/build.sh"
 unzip MUXSDKStats.xcframework.zip
 cd apps/DemoApp


### PR DESCRIPTION
## Overview
I noticed in another Buildkite run that our UI tests sometimes pass until I manually reset the simulators on the build machine. 

I realized this is because there are some code paths that only get exercised if certain events happen while the video plays - for example, `renditionchange` events. There seems to be some sort of on device caching of state (maybe `AVPlayer` does this or maybe it's a network level thing?) because unless you reset the simulator, the same events for each video do not get always fire. 

This makes sure to shutdown and erase all simulators before each test run.

