### PR TITLE
Safely remove `playbackBufferEmpty` observer

### DIFF
--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -348,6 +348,7 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
 - (void)stopMonitoringAVPlayerItem {
     [MUXSDKCore destroyPlayer: _name];
     [self safelyRemovePlayerItemObserverForKeyPath:@"status"];
+    [self safelyRemovePlayerItemObserverForKeyPath:@"playbackBufferEmpty"];
     _playerItem = nil;
 }
 


### PR DESCRIPTION
## Zube
https://zube.io/muxinc/mux/c/17447

## Overview
If the AVPlayerItem is released and we are still observing it, it can lead to this crash:
```
KVO_IS_RETAINING_ALL_OBSERVERS_OF_THIS_OBJECT_IF_IT_CRASHES_AN_OBSERVER_WAS_OVERRELEASED_OR_SMASHED
```

I recently added a new KVO observer for the player item's `playbackBufferEmpty` key without the corresponding call to remove it.
