### PR TITLE
Run unit tests as part of the BuildKite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -17,3 +17,8 @@ steps:
         - "MUXSDKStats-static.xcframework.zip"
     agents:
       queue: "iOS"
+  - wait
+  - command: ".buildkite/unit-tests.sh"
+    label: "Unit Tests"
+    agents:
+      queue: "iOS"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,4 +1,9 @@
 steps:
+  - command: ".buildkite/unit-tests.sh"
+    label: "Unit Tests"
+    agents:
+      queue: "iOS"
+  - wait
   - command: ".buildkite/build.sh"
     label: ":hammer: Build"
     artifact_paths:
@@ -15,10 +20,5 @@ steps:
     label: ":hammer: Build Static"
     artifact_paths:
         - "MUXSDKStats-static.xcframework.zip"
-    agents:
-      queue: "iOS"
-  - wait
-  - command: ".buildkite/unit-tests.sh"
-    label: "Unit Tests"
     agents:
       queue: "iOS"

--- a/.buildkite/unit-tests.sh
+++ b/.buildkite/unit-tests.sh
@@ -1,0 +1,6 @@
+PROJECT=$PWD/MUXSDKStats/MUXSDKStats.xcworkspace
+
+xcodebuild clean test \
+  -project $PROJECT \
+  -scheme MUXSDKStats \
+  -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.1' \

--- a/.buildkite/unit-tests.sh
+++ b/.buildkite/unit-tests.sh
@@ -8,6 +8,6 @@ cd ..
 PROJECT=MUXSDKStats/MUXSDKStats.xcworkspace
 
 xcodebuild clean test \
-  -project $PROJECT \
+  -workspace $PROJECT \
   -scheme MUXSDKStats \
   -destination 'platform=iOS Simulator,name=iPhone 11,OS=14.1' \

--- a/.buildkite/unit-tests.sh
+++ b/.buildkite/unit-tests.sh
@@ -1,4 +1,11 @@
-PROJECT=$PWD/MUXSDKStats/MUXSDKStats.xcworkspace
+#!/bin/bash
+set -euo pipefail
+
+cd MUXSDKStats
+pod repo update
+pod deintegrate && pod install
+cd ..
+PROJECT=MUXSDKStats/MUXSDKStats.xcworkspace
 
 xcodebuild clean test \
   -project $PROJECT \

--- a/MUXSDKStats/MUXSDKStats.xcodeproj/xcshareddata/xcschemes/MUXSDKStats.xcscheme
+++ b/MUXSDKStats/MUXSDKStats.xcodeproj/xcshareddata/xcschemes/MUXSDKStats.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1130"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4DCACFC1DCA892E0094D94C"
+               BuildableName = "MUXSDKStats.framework"
+               BlueprintName = "MUXSDKStats"
+               ReferencedContainer = "container:MUXSDKStats.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F4DCAD051DCA892E0094D94C"
+               BuildableName = "MUXSDKStatsTests.xctest"
+               BlueprintName = "MUXSDKStatsTests"
+               ReferencedContainer = "container:MUXSDKStats.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F4DCACFC1DCA892E0094D94C"
+            BuildableName = "MUXSDKStats.framework"
+            BlueprintName = "MUXSDKStats"
+            ReferencedContainer = "container:MUXSDKStats.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/MUXSDKStats/MUXSDKStats.xcodeproj/xcshareddata/xcschemes/MUXSDKStatsTv.xcscheme
+++ b/MUXSDKStats/MUXSDKStats.xcodeproj/xcshareddata/xcschemes/MUXSDKStatsTv.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F41E09031DDA8E530028A296"
+               BuildableName = "MUXSDKStats.framework"
+               BlueprintName = "MUXSDKStatsTv"
+               ReferencedContainer = "container:MUXSDKStats.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F41E09031DDA8E530028A296"
+            BuildableName = "MUXSDKStats.framework"
+            BlueprintName = "MUXSDKStatsTv"
+            ReferencedContainer = "container:MUXSDKStats.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Zube
https://zube.io/muxinc/mux/c/19047

## Overview
Takes a similar approach to what we did here, with some additional steps for Cocoapods: https://github.com/muxinc/mux-stats-sdk-objc/pull/111/

See: https://buildkite.com/mux/stats-sdk-avplayer/builds/305#