### PR TITLE
Replace identifierForVendor with alternative UUID

### DIFF
--- a/MUXSDKStats/MUXSDKStats/MUXSDKStats.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKStats.m
@@ -20,6 +20,7 @@
 // Software constants.
 NSString *const MuxPlayerSoftwareAVPlayerViewController = @"AVPlayerViewController";
 NSString *const MuxPlayerSoftwareAVPlayerLayer = @"AVPlayerLayer";
+NSString *const MuxDeviceIDUserDefaultsKey = @"MUX_DEVICE_ID";
 
 
 @implementation MUXSDKStats
@@ -61,7 +62,7 @@ static MUXSDKCustomerViewDataStore *_customerViewDataStore;
 
     // Provide EnvironmentData and ViewerData to Core.
     MUXSDKEnvironmentData *environmentData = [[MUXSDKEnvironmentData alloc] init];
-    [environmentData setMuxViewerId:[[[UIDevice currentDevice] identifierForVendor] UUIDString]];
+    [environmentData setMuxViewerId:[self getUUIDString]];
     /*
     NSString *debugData = [MUXSDKConfigParser getNSStringForKey:@"debug" fromDictionary:config];
     if (debugData) {
@@ -313,6 +314,18 @@ static MUXSDKCustomerViewDataStore *_customerViewDataStore;
     } else {
         NSLog(@"MUXSDK-ERROR - Mux failed to update the monitor because no player exists with the player name: %@", name);
     }
+}
+
+#pragma mark UUID
+
++ (NSString *)getUUIDString {
+    NSString *uuid = [[NSUserDefaults standardUserDefaults] stringForKey:MuxDeviceIDUserDefaultsKey];
+    if (uuid == nil) {
+        uuid = [[NSUUID UUID] UUIDString];
+        [[NSUserDefaults standardUserDefaults] setObject:uuid forKey:MuxDeviceIDUserDefaultsKey];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+    return uuid;
 }
 
 #pragma mark Destroy Player


### PR DESCRIPTION
Mux Viewer ID should use a random uuid, not IDFV on iOS
## Zube
https://zube.io/muxinc/mux-ios-sdks/c/3