### PR TITLE
Fix race condition when checking connection type

### DIFF
--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -109,6 +109,14 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleAVPlayerError:) name:AVPlayerItemNewErrorLogEntryNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleConnectionTypeDetected:) name:@"com.mux.connection-type-detected" object:nil];
     
+    //
+    // dylanjhaveri
+    // See MUXSDKConnection.m for the tvos shortcoming
+    //
+    if ([[UIDevice currentDevice] userInterfaceIdiom] != UIUserInterfaceIdiomTV) {
+        [MUXSDKConnection detectConnectionType];
+    }
+    
     _lastTransferEventCount = 0;
     _lastTransferDuration= 0;
     _lastTransferredBytes = 0;

--- a/MUXSDKStats/MUXSDKStats/MUXSDKStats.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKStats.m
@@ -116,13 +116,6 @@ static MUXSDKCustomerViewDataStore *_customerViewDataStore;
     [dataEvent setEnvironmentData:environmentData];
     [dataEvent setViewerData:viewerData];
     [MUXSDKCore dispatchGlobalDataEvent:dataEvent];
-    //
-    // dylanjhaveri
-    // See MUXSDKConnection.m for the tvos shortcoming
-    //
-    if (![deviceCategory isEqualToString:@"tvOS"]) {
-        [MUXSDKConnection detectConnectionType];
-    }
 }
 
 #pragma mark Monitor AVPlayerViewController

--- a/MUXSDKStats/MUXSDKStats/MUXSDKStats.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKStats.m
@@ -1,6 +1,5 @@
 #import "MUXSDKStats.h"
 #import "MUXSDKPlayerBinding.h"
-#import "MUXSDKConnection.h"
 #import "MUXSDKPlayerBindingManager.h"
 #import "MUXSDKCustomerPlayerDataStore.h"
 #import "MUXSDKCustomerVideoDataStore.h"


### PR DESCRIPTION
## Description
### Root Issue
There is a race condition in MUXSDKStats class, specifically when the monitorAVPlayerViewController method is called. Currently the initSDK method is the one that calls the `detectConnectionType` method from MUXSDKConnection (posts a notification when connection type is identified), this init is called at the very beginning of the method, after that the `attachAVPlayer` method of the new binding is called (from here we start listening for connection type notifications) and at this point the notification of the connection type might have already been broadcasted, which is the case when the connection type isn’t reflected in the dashboard.

### Solution
`detectConnectionType` call has been moved out of MUXSDKStats and now is called when `attachAVPlayer` from `MUXSDKPlayerBinding` is called, right after the binding starts listening for the connection type notification.

### Views
Before fix: https://dashboard.mux.com/organizations/jfd5eh/environments/4eao9c/views/bNZM4qquKz9VjRhNWdtYAkcw3ZIDmZ4oZjbA

With fix applied:
https://dashboard.mux.com/organizations/jfd5eh/environments/4eao9c/views/eNjZVgPcrm8PzGtJDZUzoVCdbZsNG9arlDp2

## Zube
https://zube.io/muxinc/mux-ios-sdks/c/2
