### PR TITLE
[ch712] test AVQueuePlayer

### DIFF
--- a/apps/DemoApp/DemoApp/ViewController.m
+++ b/apps/DemoApp/DemoApp/ViewController.m
@@ -25,6 +25,7 @@ NSString *const kAdTagURLStringPreRollMidRollPostRoll = @"https://pubads.g.doubl
 - (void)viewDidLoad {
     [super viewDidLoad];
     _avplayerController = [AVPlayerViewController new];
+    _avplayerController.view.accessibilityIdentifier = @"AVPlayerView";
     AVPlayer *player;
     if ([[self testScenario] isEqualToString:@"IMA"]) {
         player = [self testImaSDK];
@@ -32,6 +33,8 @@ NSString *const kAdTagURLStringPreRollMidRollPostRoll = @"https://pubads.g.doubl
         player = [self testUpdateCustomDimensions];
     } else if ([[self testScenario] isEqual:@"CHANGE_VIDEO"]) {
         player = [self testVideoChange];
+    } else if ([[self testScenario] isEqual:@"AV_QUEUE"]) {
+        player = [self testAVQueuePlayer];
     } else {
         player = [self testAVPlayer];
     }
@@ -140,6 +143,10 @@ NSString *const kAdTagURLStringPreRollMidRollPostRoll = @"https://pubads.g.doubl
 - (AVPlayer *)testAVQueuePlayer {
     AVPlayerItem *item1 = [AVPlayerItem playerItemWithURL:[NSURL URLWithString:@"https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"]];
     AVPlayerItem *item2 = [AVPlayerItem playerItemWithURL:[NSURL URLWithString:@"http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8"]];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(playerItemDidReachEnd:)
+                                                 name:AVPlayerItemDidPlayToEndTimeNotification
+                                               object:item1];
     AVQueuePlayer *player = [[AVQueuePlayer alloc] initWithItems:@[item1, item2]];
     return player;
 }
@@ -248,6 +255,13 @@ NSString *const kAdTagURLStringPreRollMidRollPostRoll = @"https://pubads.g.doubl
     videoData.videoTitle = @"Apple Keynote";
     videoData.videoId = @"applekeynote2010";
     [MUXSDKStats programChangeForPlayer:DEMO_PLAYER_NAME withVideoData:videoData];
+}
+
+- (void)playerItemDidReachEnd:(NSNotification *)notification {
+    MUXSDKCustomerVideoData *videoData = [MUXSDKCustomerVideoData new];
+    videoData.videoTitle = @"Apple Keynote";
+    videoData.videoId = @"applekeynote2010";
+    [MUXSDKStats videoChangeForPlayer:DEMO_PLAYER_NAME withVideoData:videoData];
 }
 
 - (void) updateCustomData:(NSTimer *)timer {

--- a/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
+++ b/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
@@ -50,7 +50,7 @@ NSString *const kAdTagURLStringPostRoll = @"https://pubads.g.doubleclick.net/gam
         XCTFail(@"Interrupted while playing video.");
     }
         
-    XCUIElement *element = [[[app.windows childrenMatchingType:XCUIElementTypeOther].element childrenMatchingType:XCUIElementTypeOther].element childrenMatchingType:XCUIElementTypeOther].element;
+    XCUIElement *element = app.otherElements[@"AVPlayerView"];
     [element tap];
     
     XCUIElement *skipForwardButton = app/*@START_MENU_TOKEN@*/.buttons[@"Skip Forward"]/*[[".buttons[@\"Skip 15 seconds forward\"]",".buttons[@\"Skip Forward\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/;
@@ -64,6 +64,36 @@ NSString *const kAdTagURLStringPostRoll = @"https://pubads.g.doubleclick.net/gam
     result = [XCTWaiter waitForExpectations:@[exp] timeout:10.0];
     if(result != XCTWaiterResultTimedOut) {
         XCTFail(@"Interrupted while playing video.");
+    }
+}
+
+- (void)testAVQueuePlayer {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    [app setLaunchEnvironment:@{@"ENV_KEY": @"tr4q3qahs0gflm8b1c75h49ln", @"TEST_SCENARIO": @"AV_QUEUE"}];
+    [app launch];
+    
+    // Play the first video in the queue
+    XCTestExpectation *exp = [[XCTestExpectation alloc] initWithDescription:@"Wait for 10 seconds, playing first video in queue."];
+    XCTWaiterResult result = [XCTWaiter waitForExpectations:@[exp] timeout:10.0];
+    if(result != XCTWaiterResultTimedOut) {
+        XCTFail(@"Interrupted while playing first video.");
+    }
+    
+    // Tap on AVPlayerView to get the controls section to display
+    XCUIElement *element = app.otherElements[@"AVPlayerView"];
+    [element tap];
+    
+    // Forward the video near the end
+    XCUIElement *slider = app.sliders.firstMatch;
+    XCUICoordinate *start = [slider coordinateWithNormalizedOffset:CGVectorMake(0, 0)];
+    XCUICoordinate *finish = [slider coordinateWithNormalizedOffset:CGVectorMake(0.99, 0)];
+    [start pressForDuration:1 thenDragToCoordinate:finish];
+    
+    // Play the second video in the queue
+    exp = [[XCTestExpectation alloc] initWithDescription:@"Wait for 10 seconds, playing second video in queue."];
+    result = [XCTWaiter waitForExpectations:@[exp] timeout:15.0];
+    if(result != XCTWaiterResultTimedOut) {
+        XCTFail(@"Interrupted while playing second video.");
     }
 }
 


### PR DESCRIPTION
[ch712] Issue: mux-stats-sdk-avplayer does not create new view when video changes in AVQueuePlayer.

Solution:
- Confirmed that AVQueuePlayer is working as expected.
- Fix DemoApp implementation for testAVQueuePlayer to call MUXSDKStats videoChangeForPlayer: withVideoData when getting the AVPlayerItemDidPlayToEndTimeNotification.
- Add UITest case for testAVQueuePlayer.