### PR TITLE
Add seek test cases

### DIFF
--- a/apps/DemoApp/DemoApp/ViewController.m
+++ b/apps/DemoApp/DemoApp/ViewController.m
@@ -45,6 +45,10 @@ NSString *const vodTestURL = @"http://qthttp.apple.com.edgesuite.net/1010qwoeiur
         player = [self testAVPlayer: livestreamTestURL];
     } else if ([[self testScenario] isEqual:@"LOW_LATENCY_LIVESTREAM"]) {
         player = [self testAVPlayer: livestreamLowLatencyTestURL];
+    } else if ([[self testScenario] isEqual:@"AUTO_SEEK"]) {
+        player = [self testAutoSeek];
+    } else if ([[self testScenario] isEqual:@"UI_SEEK"]) {
+        player = [self testAVPlayer:vodTestURL];
     } else {
         player = [self testAVPlayer];
     }
@@ -240,6 +244,16 @@ NSString *const vodTestURL = @"http://qthttp.apple.com.edgesuite.net/1010qwoeiur
     return player;
 }
 
+- (AVPlayer *)testAutoSeek {
+    AVPlayer *player = [AVPlayer playerWithURL:[NSURL URLWithString:vodTestURL]];
+    _timer = [NSTimer scheduledTimerWithTimeInterval:10.0
+                                              target:self
+                                            selector:@selector(autoSeek:)
+                                            userInfo:nil
+                                             repeats:NO];
+    return player;
+}
+
 - (void)setupAVPlayerViewController:(AVPlayer *)player {
     _avplayer = player;
     _avplayerController.player = _avplayer;
@@ -313,6 +327,10 @@ NSString *const vodTestURL = @"http://qthttp.apple.com.edgesuite.net/1010qwoeiur
     MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] init];
     customerData.customData = customData;
     [MUXSDKStats setCustomerData:customerData forPlayer:DEMO_PLAYER_NAME];
+}
+
+- (void)autoSeek:(NSTimer *)timer {
+    [_avplayer.currentItem seekToTime:CMTimeMakeWithSeconds(15, 60000)];
 }
 
 - (NSString *) testScenario {

--- a/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
+++ b/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
@@ -182,11 +182,14 @@ static NSString *envKey = @"tr4q3qahs0gflm8b1c75h49ln";
     XCUIElement *element = app.otherElements[@"AVPlayerView"];
     [element tap];
     
-    XCUIElement *skipForwardButton = app/*@START_MENU_TOKEN@*/.buttons[@"Skip Forward"]/*[[".buttons[@\"Skip 15 seconds forward\"]",".buttons[@\"Skip Forward\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/;
-    [skipForwardButton tap];
+    // Seek
+    XCUIElement *slider = app.sliders.firstMatch;
+    XCUICoordinate *start = [slider coordinateWithNormalizedOffset:CGVectorMake(0, 0)];
+    XCUICoordinate *finish = [slider coordinateWithNormalizedOffset:CGVectorMake(0.25, 0)];
+    [start pressForDuration:1 thenDragToCoordinate:finish];
     
-    exp = [[XCTestExpectation alloc] initWithDescription:@"Just wait for 10 seconds."];
-    result = [XCTWaiter waitForExpectations:@[exp] timeout:10.0];
+    exp = [[XCTestExpectation alloc] initWithDescription:@"Just wait for 20 seconds."];
+    result = [XCTWaiter waitForExpectations:@[exp] timeout:20.0];
     if(result != XCTWaiterResultTimedOut) {
         XCTFail(@"Interrupted while playing video.");
     }

--- a/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
+++ b/apps/DemoApp/DemoAppUITests/DemoAppUITests.m
@@ -158,4 +158,37 @@ static NSString *envKey = @"tr4q3qahs0gflm8b1c75h49ln";
         XCTFail(@"Interrupted while playing video.");
     }
 }
+
+- (void)testAutomaticSeek {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    [app setLaunchEnvironment:@{@"ENV_KEY": envKey, @"TEST_SCENARIO": @"AUTO_SEEK"}];
+    [app launch];
+    XCTestExpectation *exp = [[XCTestExpectation alloc] initWithDescription:@"Just wait for 20 seconds."];
+    XCTWaiterResult result = [XCTWaiter waitForExpectations:@[exp] timeout:20.0];
+    if(result != XCTWaiterResultTimedOut) {
+        XCTFail(@"Interrupted while playing video.");
+    }
+}
+
+- (void)testUISeek {
+    XCUIApplication *app = [[XCUIApplication alloc] init];
+    [app setLaunchEnvironment:@{@"ENV_KEY": envKey, @"TEST_SCENARIO": @"UI_SEEK"}];
+    [app launch];
+    XCTestExpectation *exp = [[XCTestExpectation alloc] initWithDescription:@"Just wait for 10 seconds."];
+    XCTWaiterResult result = [XCTWaiter waitForExpectations:@[exp] timeout:10.0];
+    if(result != XCTWaiterResultTimedOut) {
+        XCTFail(@"Interrupted while playing video.");
+    }
+    XCUIElement *element = app.otherElements[@"AVPlayerView"];
+    [element tap];
+    
+    XCUIElement *skipForwardButton = app/*@START_MENU_TOKEN@*/.buttons[@"Skip Forward"]/*[[".buttons[@\"Skip 15 seconds forward\"]",".buttons[@\"Skip Forward\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/;
+    [skipForwardButton tap];
+    
+    exp = [[XCTestExpectation alloc] initWithDescription:@"Just wait for 10 seconds."];
+    result = [XCTWaiter waitForExpectations:@[exp] timeout:10.0];
+    if(result != XCTWaiterResultTimedOut) {
+        XCTFail(@"Interrupted while playing video.");
+    }
+}
 @end


### PR DESCRIPTION
## Shortcut
https://app.shortcut.com/ios-sdks/story/11638/avplayer-2-8-0-does-not-dispatch-playing-after-seeked-event-on-programmatic-seeks

## Overview
Adds two automated UI test cases for seeking so we can make sure the views have comparable metrics. 

1. programmatic/auto seek using the `seekToTime:` API. Example: https://dashboard.mux.com/organizations/ffhei0/environments/k0vjj8/views/aPgABMPtNx87xPCRm6Ik9NC5yYUpD0JWjMD6
2. Uses slider UI control. Example: https://dashboard.mux.com/organizations/ffhei0/environments/k0vjj8/views/0RVnKALh022BkVU5MAuMd2SdVlhb7llbRN36

