### PR TITLE
Clear customer metadata stored under `playerName` when `destroyPlayer` is called

### DIFF
--- a/MUXSDKStats/MUXSDKStats/MUXSDKCustomerCustomDataStore.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKCustomerCustomDataStore.h
@@ -21,6 +21,7 @@
 @protocol MUXSDKCustomerCustomDataStoring
 
 - (void) setCustomData:(nonnull MUXSDKCustomData *)customData forPlayerName:(nonnull NSString *)name;
+- (void) removeDataForPlayerName:(nonnull NSString *)name;
 - (MUXSDKCustomData *_Nullable) customDataForPlayerName:(nonnull NSString *)name;
 
 @end

--- a/MUXSDKStats/MUXSDKStats/MUXSDKCustomerCustomDataStore.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKCustomerCustomDataStore.m
@@ -25,6 +25,10 @@
     [self.store setValue:customData forKey:name];
 }
 
+- (void)removeDataForPlayerName:(nonnull NSString *)name {
+    [self.store removeObjectForKey:name];
+}
+
 - (MUXSDKCustomData *_Nullable) customDataForPlayerName:(nonnull NSString *)name {
      return [self.store valueForKey:name];
 }

--- a/MUXSDKStats/MUXSDKStats/MUXSDKCustomerPlayerDataStore.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKCustomerPlayerDataStore.h
@@ -21,6 +21,7 @@
 @protocol MUXSDKCustomerPlayerDataStoring
 
 - (void) setPlayerData:(nonnull MUXSDKCustomerPlayerData *)playerData forPlayerName:(nonnull NSString *)name;
+- (void) removeDataForPlayerName:(nonnull NSString *)name;
 - (MUXSDKCustomerPlayerData *_Nullable) playerDataForPlayerName:(nonnull NSString *)name;
 
 @end

--- a/MUXSDKStats/MUXSDKStats/MUXSDKCustomerPlayerDataStore.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKCustomerPlayerDataStore.m
@@ -29,4 +29,7 @@
     return [self.store valueForKey:name];
 }
 
+- (void)removeDataForPlayerName:(nonnull NSString *)name {
+    [self.store removeObjectForKey:name];
+}
 @end

--- a/MUXSDKStats/MUXSDKStats/MUXSDKCustomerVideoDataStore.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKCustomerVideoDataStore.h
@@ -21,6 +21,7 @@
 @protocol MUXSDKCustomerVideoDataStoring
 
 - (void) setVideoData:(nonnull MUXSDKCustomerVideoData *)videoData forPlayerName:(nonnull NSString *)name;
+- (void) removeDataForPlayerName:(nonnull NSString *)name;
 - (MUXSDKCustomerVideoData *_Nullable) videoDataForPlayerName:(nonnull NSString *)name;
 
 @end

--- a/MUXSDKStats/MUXSDKStats/MUXSDKCustomerVideoDataStore.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKCustomerVideoDataStore.m
@@ -25,6 +25,10 @@
     [self.store setValue:videoData forKey:name];
 }
 
+- (void)removeDataForPlayerName:(nonnull NSString *)name {
+    [self.store removeObjectForKey:name];
+}
+
 - (MUXSDKCustomerVideoData *_Nullable) videoDataForPlayerName:(nonnull NSString *)name {
      return [self.store valueForKey:name];
 }

--- a/MUXSDKStats/MUXSDKStats/MUXSDKCustomerViewDataStore.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKCustomerViewDataStore.h
@@ -21,6 +21,7 @@
 @protocol MUXSDKCustomerViewDataStoring
 
 - (void) setViewData:(nonnull MUXSDKCustomerViewData *)viewData forPlayerName:(nonnull NSString *)name;
+- (void) removeDataForPlayerName:(nonnull NSString *)name;
 - (MUXSDKCustomerViewData *_Nullable) viewDataForPlayerName:(nonnull NSString *)name;
 
 @end

--- a/MUXSDKStats/MUXSDKStats/MUXSDKCustomerViewDataStore.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKCustomerViewDataStore.m
@@ -25,6 +25,10 @@
     [self.store setValue:viewData forKey:name];
 }
 
+- (void)removeDataForPlayerName:(nonnull NSString *)name {
+    [self.store removeObjectForKey:name];
+}
+
 - (MUXSDKCustomerViewData *_Nullable) viewDataForPlayerName:(nonnull NSString *)name {
      return [self.store valueForKey:name];
 }

--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBindingManager.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBindingManager.m
@@ -26,6 +26,10 @@
 
 - (void) onPlayerDestroyed:(NSString *_Nonnull) name {
     [self.playerReadyBindings removeObject:name];
+    [self.customerPlayerDataStore removeDataForPlayerName:name];
+    [self.customerVideoDataStore removeDataForPlayerName:name];
+    [self.customerViewDataStore removeDataForPlayerName:name];
+    [self.customerCustomDataStore removeDataForPlayerName:name];
 }
 
 - (BOOL) hasInitializedPlayerBinding:(NSString *) name {

--- a/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -491,6 +491,7 @@ static NSString *Z = @"Z";
     [self assertPlayer:playName dispatchedEventTypes:expectedEventTypes];
     [self assertPlayer:playName dispatchedDataEventsAtIndex:5 withCustomerVideoData:@{@"vid": @"my-video-id-2"}];
     [self assertPlayer:playName dispatchedDataEventsAtIndex:5 withCustomData:nil];
+    [MUXSDKStats destroyPlayer:playName];
 }
 
 - (void)testUpdateCustomerDataWithCustomData {

--- a/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -129,7 +129,11 @@ static NSString *Z = @"Z";
     MUXSDKCustomData *customData;
     dataEvent = (MUXSDKDataEvent * ) [MUXSDKCore eventAtIndex:index forPlayer:name];
     customData = [dataEvent customData];
-    XCTAssertTrue([[customData toQuery] isEqualToDictionary:expected]);
+    if (expected != nil) {
+        XCTAssertTrue([[customData toQuery] isEqualToDictionary:expected]);
+    } else{
+        XCTAssertNil(customData);
+    }
 }
 
 - (void) assertPlayer:(NSString *)name dispatchedDataEventsAtIndex: (int) index withCustomerViewData:(NSDictionary *) expected {
@@ -476,7 +480,7 @@ static NSString *Z = @"Z";
     MUXSDKCustomerData *updatedCustomerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:customerPlayerData
                                                                                     videoData:updatedVideoData
                                                                                      viewData:nil
-                                                                                   customData:updatedCustomData];
+                                                                                   customData:nil];
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:updatedCustomerData];
     expectedEventTypes = @[MUXSDKPlaybackEventViewInitEventType,
                            MUXSDKDataEventType,
@@ -488,7 +492,7 @@ static NSString *Z = @"Z";
     ];
     [self assertPlayer:playName dispatchedEventTypes:expectedEventTypes];
     [self assertPlayer:playName dispatchedDataEventsAtIndex:5 withCustomerVideoData:@{@"vid": @"my-video-id-2"}];
-    [self assertPlayer:playName dispatchedDataEventsAtIndex:5 withCustomData:@{@"c1" : @"bar"}];
+    [self assertPlayer:playName dispatchedDataEventsAtIndex:5 withCustomData:nil];
 }
 
 - (void)testUpdateCustomerDataWithCustomData {

--- a/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/MUXSDKStats/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -473,8 +473,6 @@ static NSString *Z = @"Z";
     [self assertPlayer:playName dispatchedDataEventsAtIndex:1 withCustomData:@{@"c1" : @"foo"}];
     
     [MUXSDKStats destroyPlayer:playName];
-    MUXSDKCustomData *updatedCustomData = [[MUXSDKCustomData alloc] init];
-    [updatedCustomData setCustomData1:@"bar"];
     MUXSDKCustomerVideoData *updatedVideoData = [[MUXSDKCustomerVideoData alloc] init];
     [updatedVideoData setVideoId:@"my-video-id-2"];
     MUXSDKCustomerData *updatedCustomerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:customerPlayerData


### PR DESCRIPTION
## Shortcut
https://app.shortcut.com/ios-sdks/story/10841/clear-customer-metadata-stored-under-playername-when-destroy-player-is-called

## Overview

We need to make sure to clear out all customer metadata when a player monitor is destroyed so that the same player name may be reused. 