### PR TITLE
Fix crash in `AVMetadataItem` inspection

### DIFF
--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -401,10 +401,13 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     [asset loadValuesAsynchronouslyForKeys:@[@"metadata"] completionHandler:^{
         NSMutableDictionary *sessionData = [[NSMutableDictionary alloc] init];
         for (AVMetadataItem *item in asset.metadata) {
-            NSString *keyString = (NSString *)[item key];
-            if ([keyString hasPrefix:MUXSessionDataPrefix]) {
-                NSString *itemKey = [keyString substringFromIndex:[MUXSessionDataPrefix length]];
-                [sessionData setObject:[item value] forKey:itemKey];
+            id<NSObject, NSCopying> key = [item key];
+            if ([key isKindOfClass:[NSString class]]) {
+                NSString *keyString = (NSString *)key;
+                if ([keyString hasPrefix:MUXSessionDataPrefix]) {
+                    NSString *itemKey = [keyString substringFromIndex:[MUXSessionDataPrefix length]];
+                    [sessionData setObject:[item value] forKey:itemKey];
+                }
             }
         }
         


### PR DESCRIPTION
These changes prevent a crash caused by casting `[AVMetadataItem key]` to an `NSString` without checking the type first.

`[AVMetadataItem key]` is defined as `id<NSObject, NSCopying>` since it can be a type other than `NSString`. 

I'm witnessing crashes in v1.12.0 due to `[AVMetadataItem key]` returning an `NSNumber` and the line `[keyString hasPrefix:MUXSessionDataPrefix]` throws an `unrecognized selector sent to instance` exception.

These changes check that  `[AVMetadataItem key]` is an `NSString` before casting to it.