### PR TITLE
ci: update iOS Simulator and macOS versions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Run unit tests and build the SDK
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Install xcbeautify
         run: brew install xcbeautify
@@ -30,18 +30,12 @@ jobs:
   tests:
     name: Test the SDK with a Demo App
     needs: build
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Install xcbeautify
         run: brew install xcbeautify
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Link to older simulator(s)
-        run: |
-          echo "Creating Runtimes folder if needed..."
-          sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-          echo "Creating symlink of the iOS 14.1 runtime..."
-          sudo ln -s /Applications/Xcode_12.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 14.1.simruntime
       - name: Download framework artifact
         uses: actions/download-artifact@v2
         with:
@@ -50,16 +44,10 @@ jobs:
         run: "apps/DemoApp/run-tests.sh"
   build-static:
     name: Build static SDK
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Link to older simulator(s)
-        run: |
-          echo "Creating Runtimes folder if needed..."
-          sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-          echo "Creating symlink of the iOS 14.1 runtime..."
-          sudo ln -s /Applications/Xcode_12.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 14.1.simruntime
       - name: "🔨 Build Static"
         run: ".github/workflows/scripts/build-static.sh"
       - name: "Upload framework artifact"
@@ -70,7 +58,7 @@ jobs:
   tests-iOS-15:
     name: (iOS 15) Test the SDK with a Demo App
     needs: build
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Install xcbeautify
         run: brew install xcbeautify
@@ -80,5 +68,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: "MUXSDKStats.xcframework.zip"
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_13.4.1.app/Contents/Developer'
       - name: Run tests
         run: "apps/DemoApp/run-tests-big-sur.sh"

--- a/apps/DemoApp/run-tests-big-sur.sh
+++ b/apps/DemoApp/run-tests-big-sur.sh
@@ -3,27 +3,20 @@ set -euo pipefail
 
 brew install xcbeautify
 
+echo "Running unit tests on Xcode version: $(xcode-select -p)"
+
 # Delete the old stuff
 rm -Rf XCFramework
 # reset simulators
 xcrun -v simctl shutdown all
 xcrun -v simctl erase all
 
-# Fetch artifact if running via buildkite (GitHub Actions fetches the artifact in a prior step)
-if command -v buildkite-agent > /dev/null 2>&1;
-then
-    buildkite-agent artifact download "MUXSDKStats.xcframework.zip" . --step ".buildkite/build.sh"
-fi
-
-echo "========= test xcode version"
-xcodebuild -version
-
 unzip MUXSDKStats.xcframework.zip
 cd apps/DemoApp
 pod deintegrate && pod update
 xcodebuild -workspace DemoApp.xcworkspace \
            -scheme "DemoApp" \
-           -destination 'platform=iOS Simulator,name=iPhone 13,OS=15.2' \
+           -destination 'platform=iOS Simulator,name=iPhone 13,OS=15.5' \
            test \
            | xcbeautify
 

--- a/apps/DemoApp/run-tests.sh
+++ b/apps/DemoApp/run-tests.sh
@@ -19,7 +19,7 @@ pod deintegrate && pod update
 
 xcodebuild -workspace DemoApp.xcworkspace \
            -scheme "DemoApp" \
-           -destination 'platform=iOS Simulator,name=iPhone 13,OS=16.2' \
+           -destination 'platform=iOS Simulator,OS=16.2,name=iPhone 14 Pro Max' \
            test \
            | xcbeautify
 


### PR DESCRIPTION
Update macOS version to Ventura

Use existing simulator when running tests

Use Xcode 13.4.1 to test iOS 15 and use the right iOS 15 version

Remove link to older simulators from GitHub Action config