### PR TITLE
fix: remove public accessors for player software name and version

### DIFF
--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.h
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.h
@@ -118,14 +118,6 @@ typedef NS_ENUM(NSUInteger, MUXSDKViewOrientation) {
 
 #pragma clang diagnostic pop
 
-/// Player software name reported by events dispatched
-/// by this binding
-@property (nonatomic, nullable) NSString *softwareName;
-
-/// Player software version reported by events dispatched
-/// by this binding
-@property (nonatomic, nullable) NSString *softwareVersion;
-
 - (nonnull id)initWithPlayerName:(nonnull NSString *)playerName
                     softwareName:(nullable NSString *)softwareName;
 

--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -86,22 +86,6 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     return _automaticVideoChange;
 }
 
-- (NSString *)softwareName {
-    return _softwareName;
-}
-
-- (void)setSoftwareName:(NSString *)softwareName {
-    _softwareName = softwareName;
-}
-
-- (NSString *)softwareVersion {
-    return _softwareVersion;
-}
-
-- (void)setSoftwareVersion:(NSString *)softwareVersion {
-    _softwareVersion = softwareVersion;
-}
-
 - (void)attachAVPlayer:(AVPlayer *)player {
     if (_player) {
         [self detachAVPlayer];


### PR DESCRIPTION
Removing these because these dimensions can only be set once. As a result once the first value is received by the server the player software name and version cannot be altered by the next beacon in sequence.

Reflect that restriction in the API by allowing them to only be set once at initialization time.

To minimize exposed API surface this PR removes both of the newly added getters too, we can add them back as `readonly` properties in a future release.