### PR TITLE
chore: remove deprecated interfaces

### DIFF
--- a/Sources/MUXSDKStatsObjc/MUXSDKPlayerBinding.h
+++ b/Sources/MUXSDKStatsObjc/MUXSDKPlayerBinding.h
@@ -132,21 +132,6 @@ typedef NS_ENUM(NSUInteger, MUXSDKViewOrientation) {
     AVPlayerViewController *_viewController;
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullability-completeness"
-
-/// Initializes a binding that listens for and dispatches player events
-/// - Parameters:
-///   - name: A name for this instance of the player
-///   - software: The name of the underlying player software
-///   - view: An AVPlayerViewController to monitor using this binding
-- (id)initWithName:(NSString *)name
-          software:(NSString *)software
-           andView:(AVPlayerViewController *)view __attribute__((deprecated("Please migrate to initWithPlayerName:softwareName:playerViewController:")));
-
-#pragma clang diagnostic pop
-
-
 /// Initializes a binding that listens for and dispatches player events
 /// - Parameters:
 ///   - playerName: A name for this instance of the player
@@ -175,22 +160,6 @@ typedef NS_ENUM(NSUInteger, MUXSDKViewOrientation) {
     AVPlayerLayer *_view;
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullability-completeness"
-
-
-/// Initializes a binding that listens for and dispatches player events
-/// - Parameters:
-///   - name: A name for this instance of the player
-///   - software: The name of the underlying player software
-///   - view: An AVPlayerLayer to monitor
-- (id)initWithName:(NSString *)name
-          software:(NSString *)software
-           andView:(AVPlayerLayer *)view __attribute__((deprecated("Please migrate to initWithPlayerName:softwareName:playerLayer:")));;
-
-#pragma clang diagnostic pop
-
-
 /// Initializes a binding that listens for and dispatches player events
 /// - Parameters:
 ///   - playerName: A name for this instance of the player
@@ -218,7 +187,6 @@ typedef NS_ENUM(NSUInteger, MUXSDKViewOrientation) {
 @private
     CGSize _fixedPlayerSize;
 }
-
 
 /// Initializes a binding that listens for and dispatches player events
 /// - Parameters:

--- a/Sources/MUXSDKStatsObjc/MUXSDKStats.h
+++ b/Sources/MUXSDKStatsObjc/MUXSDKStats.h
@@ -1,25 +1,6 @@
-/*
-    File:  MUXSDKStats.h
-
-	Framework:  MUXSDKStats
-
-	Copyright © 2016 Mux, Inc. All rights reserved.
- */
-
-/*!
-	@class			MUXSDKStats
-
-	@abstract
- MUXSDKStats offers an interface for monitoring video players.
-
-	@discussion
- MUXSDKStats monitors an AVPlayer performance by sending tracking pings to Mux servers.
-
- In the simplest use case, an AVPlayer can be provided to the MUXSDKStats API and everything else is taken care of for you. The MUXSDKStats monitor methods attach a set of timed state and key-value observers on the AVPlayer. When you are done with an AVPlayer instance, call destroyPlayer: to remove the observers.
-
- If you change the video that is playing in an AVPlayer, you should call videoChangeForPlayer:withVideoData to provide the updated video information. Not calling videoChangeForPlayer:withVideoData when the video changes will cause tracking pings to be associated with the last video that was playing.
- */
-
+//
+//  MUSDKStats.h
+//  MUXSDKStats
 
 #if __has_feature(modules)
 @import Foundation;
@@ -40,6 +21,23 @@
 #endif
 #import "MUXSDKPlayerBinding.h"
 
+/// MUXSDKStats monitors an AVPlayer performance by sending
+/// tracking pings to Mux servers. 
+///
+/// In the simplest use case,
+/// an AVPlayer can be provided to the MUXSDKStats API and
+/// everything else is taken care of for you. The MUXSDKStats
+/// monitor methods attach a set of timed state and key-value
+/// observers on the AVPlayer. When you are done with an
+/// AVPlayer instance, call destroyPlayer: to remove the
+/// observers.
+///
+/// If you change the video that is playing in an AVPlayer,
+/// you should call videoChangeForPlayer:withVideoData to
+/// provide the updated video information. Not calling
+/// videoChangeForPlayer:withVideoData when the video changes
+/// will cause tracking pings to be associated with the last
+/// video that was playing.
 FOUNDATION_EXPORT
 @interface MUXSDKStats : NSObject
 
@@ -48,335 +46,221 @@ FOUNDATION_EXPORT
 
 #pragma mark - AVPlayerViewController Monitoring
 
-/*!
- @method      monitorAVPlayerViewController:withPlayerName:customerData:
- @abstract    Starts to monitor a given AVPlayerViewController.
- @param       player An AVPlayerViewController to monitor
- @param       name A name for this instance of the player
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @return      an instance of MUXSDKAVPlayerViewControllerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
+/// Starts to monitor a given AVPlayerViewController.
+///
+/// Use this method to start a Mux player monitor on the
+/// given AVPlayerViewController. The player must have a name
+/// which is globally unique. The config provided should match
+/// the specifications in the Mux docs at https://docs.mux.com
+/// - Parameters:
+///   - player: An AVPlayerViewController to monitor
+///   - name: A name for this instance of the player
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+/// - Returns: an instance of MUXSDKAVPlayerViewControllerBinding
+/// or nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
                                                  withPlayerName:(nonnull NSString *)name
                                                    customerData:(nonnull MUXSDKCustomerData *)customerData;
 
-/*!
- @method      monitorAVPlayerViewController:withPlayerName:customerData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerViewController.
- @param       player An AVPlayerViewController to monitor
- @param       name A name for this instance of the player
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @return      an instance of MUXSDKAVPlayerViewControllerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
+/// Starts to monitor a given AVPlayerViewController.
+///
+/// Use this method to start a Mux player monitor on the
+/// given AVPlayerViewController. The player must have a name
+/// which is globally unique. The config provided should match
+/// the specifications in the Mux docs at https://docs.mux.com
+/// - Parameters:
+///   - player: An AVPlayerViewController to monitor
+///   - name: A name for this instance of the player
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+///   - automaticErrorTracking: boolean to indicate if the
+/// SDK should automatically track player errors
+/// - Returns: an instance of MUXSDKAVPlayerViewControllerBinding
+/// or nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
                                                  withPlayerName:(nonnull NSString *)name
                                                    customerData:(nonnull MUXSDKCustomerData *)customerData
                                          automaticErrorTracking:(BOOL)automaticErrorTracking;
 
-/*!
- @method      monitorAVPlayerViewController:withPlayerName:customerData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerViewController.
- @param       player An AVPlayerViewController to monitor
- @param       name A name for this instance of the player
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @param       collectionDomain Domain to send tracking data to, if you want to use a custom beacon domain. Optional.
- @return      an instance of MUXSDKAVPlayerViewControllerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
+/// Starts to monitor a given AVPlayerViewController.
+///
+/// Use this method to start a Mux player monitor on the
+/// given AVPlayerViewController. The player must have a
+/// name which is globally unique. The config provided
+/// should match the specifications in the Mux docs at
+/// https://docs.mux.com
+///
+/// - Parameters:
+///   - player: An AVPlayerViewController to monitor
+///   - name: A name for this instance of the player
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+///   - automaticErrorTracking: boolean to indicate if the
+/// SDK should automatically track player errors
+///   - collectionDomain: Domain to send tracking data to,
+/// if you want to use a custom beacon domain. Optional.
+/// - Returns: an instance of MUXSDKAVPlayerViewControllerBinding
+/// or nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
                                                  withPlayerName:(nonnull NSString *)name
                                                    customerData:(nonnull MUXSDKCustomerData *)customerData
                                          automaticErrorTracking:(BOOL)automaticErrorTracking
                                          beaconCollectionDomain:(nullable NSString *)collectionDomain;
 
-/*!
- @method      monitorAVPlayerViewController:withPlayerName:customerData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerViewController.
- @param       player An AVPlayerViewController to monitor
- @param       name A name for this instance of the player
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @param       domain Domain to send tracking data to, if you want to use a custom beacon domain. Optional.
- @return      an instance of MUXSDKAVPlayerViewControllerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
-                                                 withPlayerName:(nonnull NSString *)name
-                                                   customerData:(nonnull MUXSDKCustomerData *)customerData
-                                         automaticErrorTracking:(BOOL)automaticErrorTracking
-                                                   beaconDomain:(nullable NSString *)domain
-__attribute__((deprecated("Please migrate to monitorAVPlayerViewController:withPlayerName:customerData:automaticErrorTracking:beaconCollectionDomain:")));
-
-/*!
- @method      monitorAVPlayerViewController:withPlayerName:playerData:videoData:
- @abstract    Starts to monitor a given AVPlayerViewController.
- @param       player An AVPlayerViewController to monitor
- @param       name A name for this instance of the player
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @return      an instance of MUXSDKAVPlayerViewControllerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player 
-                                                 withPlayerName:(nonnull NSString *)name
-                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData __attribute__((deprecated("Please migrate to monitorAVPlayerViewController:withPlayerName:customerData:")));
-
-/*!
- @method      monitorAVPlayerViewController:withPlayerName:playerData:videoData:viewData:
- @abstract    Starts to monitor a given AVPlayerViewController.
- @param       player An AVPlayerViewController to monitor
- @param       name A name for this instance of the player
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @param       viewData A MUXSDKCustomerViewData object with view metadata
- @return      an instance of MUXSDKAVPlayerViewControllerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player 
-                                                 withPlayerName:(nonnull NSString *)name
-                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                                       viewData: (nullable MUXSDKCustomerViewData *) viewData __attribute__((deprecated("Please migrate to monitorAVPlayerViewController:withPlayerName:customerData:")));
-
-/*!
- @method      monitorAVPlayerViewController:withPlayerName:playerData:videoData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerViewController.
- @param       player An AVPlayerViewController to monitor
- @param       name A name for this instance of the player
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @return      an instance of MUXSDKAVPlayerViewControllerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player 
-                                                 withPlayerName:(nonnull NSString *)name
-                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                         automaticErrorTracking:(BOOL)automaticErrorTracking __attribute__((deprecated("Please migrate to monitorAVPlayerViewController:withPlayerName:customerData:automaticErrorTracking:")));
-/*!
- @method      monitorAVPlayerViewController:withPlayerName:playerData:videoData:viewData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerViewController.
- @param       player An AVPlayerViewController to monitor
- @param       name A name for this instance of the player
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @param       viewData A MUXSDKCustomerViewData object with view metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @return      an instance of MUXSDKAVPlayerViewControllerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerViewController. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player 
-                                                 withPlayerName:(nonnull NSString *)name
-                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                                       viewData: (nullable MUXSDKCustomerViewData *) viewData
-                                         automaticErrorTracking:(BOOL)automaticErrorTracking __attribute__((deprecated("Please migrate to monitorAVPlayerViewController:withPlayerName:customerData:automaticErrorTracking:")));
-
-/*!
- @method      updateAVPlayerViewController:withPlayerName
- @abstract    Updates the monitor for a player to a new AVPlayerViewController.
- @param       player The new AVPlayerViewController to monitor
- @param       name The name of the player instance to update
- @discussion  Use this method to change which AVPlayerViewController a Mux player monitor is watching. The player monitor must previously have been created via a monitorAVPlayerViewController call.
- */
-+ (void)updateAVPlayerViewController:(nonnull AVPlayerViewController *)player 
+/// Updates the monitor for a player to a new AVPlayerViewController.
+///
+/// Use this method to change which AVPlayerViewController a
+/// Mux player monitor is watching. The player monitor must
+/// previously have been created via a monitorAVPlayerViewController
+/// call.
+/// - Parameters:
+///   - player: The new AVPlayerViewController to monitor
+///   - name: The name of the player instance to update
++ (void)updateAVPlayerViewController:(nonnull AVPlayerViewController *)player
                       withPlayerName:(nonnull NSString *)name;
 
 #pragma mark - AVPlayerLayer Monitoring
 
-/*!
- @method      monitorAVPlayerLayer:withPlayerName:customerData:
- @abstract    Starts to monitor a given AVPlayerLayer.
- @param       player An AVPlayerLayer to monitor
- @param       name A name for this instance of the player
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @return      an instance of MUXSDKAVPlayerLayerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerLayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
+/// Starts to monitor a given AVPlayerLayer.
+///
+/// Use this method to start a Mux player monitor on the
+/// given AVPlayerLayer. The player must have a name which
+/// is globally unique. The config provided should match the
+/// specifications in the Mux docs at https://docs.mux.com
+/// - Parameters:
+///   - player: An AVPlayerLayer to monitor
+///   - name: A name for this instance of the player
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+/// - Returns: an instance of MUXSDKAVPlayerLayerBinding or
+/// nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
                                         withPlayerName:(nonnull NSString *)name
                                           customerData:(nonnull MUXSDKCustomerData *)customerData;
 
-/*!
- @method      monitorAVPlayerLayer:withPlayerName:customerData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerLayer.
- @param       player An AVPlayerLayer to monitor
- @param       name A name for this instance of the player
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @return      an instance of MUXSDKAVPlayerLayerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerLayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
+/// Starts to monitor a given AVPlayerLayer.
+///
+/// Use this method to start a Mux player monitor on the
+/// given AVPlayerLayer. The player must have a name which
+/// is globally unique. The config provided should match the
+/// specifications in the Mux docs at https://docs.mux.com
+/// - Parameters:
+///   - player: An AVPlayerLayer to monitor
+///   - name: A name for this instance of the player
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+///   - automaticErrorTracking: boolean to indicate if the
+/// SDK should automatically track player errors
+/// - Returns: an instance of MUXSDKAVPlayerLayerBinding or
+/// nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
                                         withPlayerName:(nonnull NSString *)name
                                           customerData:(nonnull MUXSDKCustomerData *)customerData
                                 automaticErrorTracking:(BOOL)automaticErrorTracking;
 
-/*!
- @method      monitorAVPlayerLayer:withPlayerName:customerData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerLayer.
- @param       player An AVPlayerLayer to monitor
- @param       name A name for this instance of the player
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @param       collectionDomain Domain to send tracking data to, if you want to use a custom beacon domain. Optional.
- @return      an instance of MUXSDKAVPlayerLayerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerLayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
+/// Starts to monitor a given AVPlayerLayer.
+///
+/// Use this method to start a Mux player monitor on the
+/// given AVPlayerLayer. The player must have a name which
+/// is globally unique. The config provided should match the
+/// specifications in the Mux docs at https://docs.mux.com
+/// - Parameters:
+///   - player: An AVPlayerLayer to monitor
+///   - name: A name for this instance of the player
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+///   - automaticErrorTracking: boolean to indicate if the
+/// SDK should automatically track player errors
+///   - collectionDomain: Domain to send tracking data to,
+/// if you want to use a custom beacon domain. Optional.
+/// - Returns: an instance of MUXSDKAVPlayerLayerBinding or
+/// nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
                                         withPlayerName:(nonnull NSString *)name
                                           customerData:(nonnull MUXSDKCustomerData *)customerData
                                 automaticErrorTracking:(BOOL)automaticErrorTracking
-                                          beaconCollectionDomain:(nullable NSString *)collectionDomain;
-/*!
- @method      monitorAVPlayerLayer:withPlayerName:customerData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerLayer.
- @param       player An AVPlayerLayer to monitor
- @param       name A name for this instance of the player
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @param       domain Domain to send tracking data to, if you want to use a custom beacon domain. Optional.
- @return      an instance of MUXSDKAVPlayerLayerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerLayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
-                                        withPlayerName:(nonnull NSString *)name
-                                          customerData:(nonnull MUXSDKCustomerData *)customerData
-                                automaticErrorTracking:(BOOL)automaticErrorTracking
-                                          beaconDomain:(nullable NSString *)domain
-__attribute__((deprecated("Please migrate to monitorAVPlayerLayer:withPlayerName:customerData:automaticErrorTracking:beaconCollectionDomain:")));
+                                beaconCollectionDomain:(nullable NSString *)collectionDomain;
 
-
-/*!
- @method      monitorAVPlayerLayer:withPlayerName:playerData:videoData:
- @abstract    Starts to monitor a given AVPlayerLayer.
- @param       player An AVPlayerLayer to monitor
- @param       name A name for this instance of the player
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @return      an instance of MUXSDKAVPlayerLayerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerLayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player 
-                                        withPlayerName:(nonnull NSString *)name
-                                            playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                             videoData:(nullable MUXSDKCustomerVideoData *)videoData __attribute__((deprecated("Please migrate to monitorAVPlayerLayer:withPlayerName:customerData:")));
-
-
-/*!
- @method      monitorAVPlayerLayer:withPlayerName:playerData:videoData:viewData:
- @abstract    Starts to monitor a given AVPlayerLayer.
- @param       player An AVPlayerLayer to monitor
- @param       name A name for this instance of the player
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @param       viewData A MUXSDKCustomerViewData object with view metadata
- @return      an instance of MUXSDKAVPlayerLayerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerLayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player 
-                                        withPlayerName:(nonnull NSString *)name
-                                            playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                             videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                              viewData: (nullable MUXSDKCustomerViewData *) viewData __attribute__((deprecated("Please migrate to monitorAVPlayerLayer:withPlayerName:customerData:")));
-
-
-/*!
- @method      monitorAVPlayerLayer:withPlayerName:playerData:videoData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerLayer.
- @param       player An AVPlayerLayer to monitor
- @param       name A name for this instance of the player
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @return      an instance of MUXSDKAVPlayerLayerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerLayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player 
-                                        withPlayerName:(nonnull NSString *)name
-                                            playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                             videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                automaticErrorTracking:(BOOL)automaticErrorTracking __attribute__((deprecated("Please migrate to monitorAVPlayerLayer:withPlayerName:customerData:automaticErrorTracking:")));
-
-/*!
- @method      monitorAVPlayerLayer:withPlayerName:playerData:videoData:viewData:automaticErrorTracking:
- @abstract    Starts to monitor a given AVPlayerLayer.
- @param       player An AVPlayerLayer to monitor
- @param       name A name for this instance of the player
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @param       viewData A MUXSDKCustomerViewData object with view metadata
- @param       automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @return      an instance of MUXSDKAVPlayerLayerBinding or null
- @discussion  Use this method to start a Mux player monitor on the given AVPlayerLayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
- */
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player 
-                                        withPlayerName:(nonnull NSString *)name
-                                            playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                             videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                              viewData: (nullable MUXSDKCustomerViewData *) viewData
-                                automaticErrorTracking:(BOOL)automaticErrorTracking __attribute__((deprecated("Please migrate to monitorAVPlayerLayer:withPlayerName:customerData:automaticErrorTracking:")));
-
-
-/*!
- @method      updateAVPlayerLayer:withPlayerName:
- @abstract    Updates the monitor for a player to a new AVPlayerLayer.
- @param       player The new AVPlayerLayer to monitor
- @param       name The name of the player instance to update
- @discussion  Use this method to change which AVPlayerLayer a Mux player monitor is watching. The player monitor must previously have been created via a monitorAVPlayerLayer call.
- */
-+ (void)updateAVPlayerLayer:(nonnull AVPlayerLayer *)player 
+/// Updates the monitor for a player to a new AVPlayerLayer.
+///
+/// Use this method to change which AVPlayerLayer a Mux
+/// player monitor is watching. The player monitor must
+/// previously have been created via a monitorAVPlayerLayer
+/// call.
+/// - Parameters:
+///   - player: The new AVPlayerLayer to monitor
+///   - name: The name of the player instance to update
++ (void)updateAVPlayerLayer:(nonnull AVPlayerLayer *)player
              withPlayerName:(nonnull NSString *)name;
 
 #pragma mark - AVPlayer Monitoring
 
-/*
- @method   monitorAVPlayer:withPlayerName:fixedPlayerSize:customerData:
- @abstract Starts to monitor a given AVPlayer.
- @param    player An AVPlayer to monitor
- @param    name A name for this instance of the player
- @param    A fixed size of your player that will not change, inclusive of any letter boxed or pillar boxed areas. If monitoring audio only media, pass in CGSizeMake(0.0, 0.0)
- @param    customerData A MUXSDKCustomerData object with player, video, and view metadata
- @discussion Use this method to start a Mux player monitor on the given AVPlayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
-*/
+/// Starts to monitor a given AVPlayer.
+///
+/// Use this method to start a Mux player monitor on the given
+/// AVPlayer. The player must have a name which is globally
+/// unique. The config provided should match the specifications
+/// in the Mux docs at https://docs.mux.com
+/// - Parameters:
+///   - player: An AVPlayer to monitor
+///   - name: A name for this instance of the player
+///   - fixedPlayerSize: A fixed size of your player that will
+///   not change, inclusive of any letter boxed or pillar
+///   boxed areas. If monitoring audio only media, pass in
+///   CGSizeMake(0.0, 0.0)
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+/// - Returns: an instance of MUXSDKPlayerBinding or nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayer:(nonnull AVPlayer *)player
                                    withPlayerName:(nonnull NSString *)name
                                   fixedPlayerSize:(CGSize)fixedPlayerSize
                                      customerData:(nonnull MUXSDKCustomerData *)customerData;
 
-/*
- @method   monitorAVPlayer:withPlayerName:fixedPlayerSize:customerData:
- @abstract Starts to monitor a given AVPlayer.
- @param    player An AVPlayer to monitor
- @param    name A name for this instance of the player
- @param    fixedPlayerSize A fixed size of your player that will not change, inclusive of any letter boxed or pillar boxed areas. If monitoring audio only media, pass in CGSizeMake(0.0, 0.0)
- @param    customerData A MUXSDKCustomerData object with player, video, and view metadata
- @param    automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @discussion Use this method to start a Mux player monitor on the given AVPlayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
-*/
+/// Starts to monitor a given AVPlayer.
+///
+/// Use this method to start a Mux player monitor on the given
+/// AVPlayer. The player must have a name which is globally
+/// unique. The config provided should match the specifications
+/// in the Mux docs at https://docs.mux.com
+/// - Parameters:
+///   - player: An AVPlayer to monitor
+///   - name: A name for this instance of the player
+///   - fixedPlayerSize: A fixed size of your player that will
+///   not change, inclusive of any letter boxed or pillar
+///   boxed areas. If monitoring audio only media, pass in
+///   CGSizeMake(0.0, 0.0)
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+///   - automaticErrorTracking: boolean to indicate if the
+///   SDK should automatically track player errors
+/// - Returns: an instance of MUXSDKPlayerBinding or nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayer:(nonnull AVPlayer *)player
                                    withPlayerName:(nonnull NSString *)name
                                   fixedPlayerSize:(CGSize)fixedPlayerSize
                                      customerData:(nonnull MUXSDKCustomerData *)customerData
                            automaticErrorTracking:(BOOL)automaticErrorTracking;
 
-/*
- @method   monitorAVPlayer:withPlayerName:fixedPlayerSize:customerData:
- @abstract Starts to monitor a given AVPlayer.
- @param    player An AVPlayer to monitor
- @param    name A name for this instance of the player
- @param    fixedPlayerSize A fixed size of your player that will not change, inclusive of any letter boxed or pillar boxed areas. If monitoring audio only media, pass in CGSizeMake(0.0, 0.0)
- @param    customerData A MUXSDKCustomerData object with player, video, and view metadata
- @param    automaticErrorTracking boolean to indicate if the SDK should automatically track player errors
- @param    collectionDomain Domain to send tracking data to, if you want to use a custom beacon domain. Optional.
- @discussion Use this method to start a Mux player monitor on the given AVPlayer. The player must have a name which is globally unique. The config provided should match the specifications in the Mux docs at https://docs.mux.com
-*/
+/// Starts to monitor a given AVPlayer.
+///
+/// Use this method to start a Mux player monitor on the given
+/// AVPlayer. The player must have a name which is globally
+/// unique. The config provided should match the specifications
+/// in the Mux docs at https://docs.mux.com
+/// - Parameters:
+///   - player: An AVPlayer to monitor
+///   - name: A name for this instance of the player
+///   - fixedPlayerSize: A fixed size of your player that will
+///   not change, inclusive of any letter boxed or pillar
+///   boxed areas. If monitoring audio only media, pass in
+///   CGSizeMake(0.0, 0.0)
+///   - customerData: A MUXSDKCustomerData object with player,
+/// video, and view metadata
+///   - automaticErrorTracking: boolean to indicate if the
+///   SDK should automatically track player errors
+///   - collectionDomain: Domain to send tracking data to,
+///   if you want to use a custom beacon domain. Optional.
+/// - Returns: an instance of MUXSDKPlayerBinding or nil
 + (MUXSDKPlayerBinding *_Nullable)monitorAVPlayer:(nonnull AVPlayer *)player
                                    withPlayerName:(nonnull NSString *)name
                                   fixedPlayerSize:(CGSize)fixedPlayerSize
@@ -384,151 +268,105 @@ __attribute__((deprecated("Please migrate to monitorAVPlayerLayer:withPlayerName
                            automaticErrorTracking:(BOOL)automaticErrorTracking
                            beaconCollectionDomain:(nullable NSString *)collectionDomain;
 
-/*!
- @method      updateAVPlayer:withPlayerName:fixedPlayerSize:
- @abstract    Updates the monitor for a player to a new AVPlayer.
- @param       player The new AVPlayer to monitor
- @param       name The name of the player instance to update
- @param       fixedPlayerSize A fixed size of your player that will not change, inclusive of any letter boxed or pillar boxed areas. If monitoring audio only media, pass in CGSizeMake(0.0, 0.0)
- @discussion  Use this method to change which AVPlayer a Mux player monitor is watching. The player monitor must previously have been created via a monitorAVPlayer call.
- */
+/// Updates the monitor for a player to a new AVPlayer.
+///
+/// Use this method to change which AVPlayer a Mux player
+/// monitor is watching. The player monitor must previously
+/// have been created via a monitorAVPlayer call.
+/// - Parameters:
+///   - player: The new AVPlayer to monitor
+///   - name: The name of the player instance to update
+///   - fixedPlayerSize: A fixed size of your player that will
+///   not change, inclusive of any letter boxed or pillar
+///   boxed areas. If monitoring audio only media, pass in
+///   CGSizeMake(0.0, 0.0)
 + (void)updateAVPlayer:(nonnull AVPlayer *)player
         withPlayerName:(nonnull NSString *)name
        fixedPlayerSize:(CGSize)fixedPlayerSize;
 
 #pragma mark - Teardown Monitoring
 
-/*!
- @method			destroyPlayer:
- @abstract    Removes any AVPlayer observers on the associated player.
- @param       name The name of the player to destory
- @discussion  When you are done with a player, call destoryPlayer: to remove all observers that were set up when monitorPlayer:withPlayerName:andConfig: was called and to ensure that any remaining tracking pings are sent to complete the view. If the name of the player provided was not previously initialized, an exception will be raised.
- */
+/// Removes any AVPlayer observers on the associated player.
+///
+/// When you are done with a player, call destoryPlayer:
+/// to remove all observers that were set up when
+/// monitorPlayer:withPlayerName:andConfig: was called and
+/// to ensure that any remaining tracking pings are sent to
+/// complete the view. If the name of the player provided was
+/// not previously initialized, an exception will be raised.
+/// - Parameters:
+///   - name: The name of the player to destroy
 + (void)destroyPlayer:(nonnull NSString *)name;
 
 #pragma mark - Automatic Video Change
 
-/*!
- @method      setAutomaticVideoChange:forPlayer:enabled
- @abstract    Allows default videochange functionality to be disabled.
- @param       name The name of the player to update
- @discussion  Use this method to disable built in videochange calls when using AVQueuePlayer. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should set the enabled value to false. The default setting is true.
-
- */
-+ (void)setAutomaticVideoChange:(nonnull NSString *)name 
+/// Allows default videochange functionality to be disabled.
+///
+/// Use this method to disable built in videochange calls
+/// when using AVQueuePlayer. The player name provided must
+/// been passed as the name in a monitorPlayer:withPlayerName:andConfig:
+/// call. The config provided should match the specifications
+/// in the Mux docs at https://docs.mux.com and should set
+/// the enabled value to false. The default setting is true.
+/// - Parameters:
+///   - name: The name of the player to update
+///   - enabled: Boolean indicating if automatic video change
+///   is enabled or not
++ (void)setAutomaticVideoChange:(nonnull NSString *)name
                         enabled:(Boolean)enabled;
 
 #pragma mark - Manual Video Change
 
-/*!
- @method      videoChangeForPlayer:withCustomerData:
- @abstract    Signals that a player is now playing a different video.
- @param       name The name of the player to update
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @discussion  Use this method to signal that the player is now playing a new video. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should include all desired keys, not just those keys that are specific to this video. If the name of the player provided was not previously initialized, an exception will be raised.
-
- */
+/// Signals that a player is now playing a different video.
+///
+/// Use this method to signal that the player is now playing
+/// a new video. The player name provided must been passed
+/// as the name in a monitorPlayer:withPlayerName:andConfig:
+/// call. The config provided should match the specifications
+/// in the Mux docs at https://docs.mux.com and should include
+/// all desired keys, not just those keys that are specific
+/// to this video. If the name of the player provided was not
+/// previously initialized, an exception will be raised.
+/// - Parameters:
+///   - name: The name of the player to update
+///   - customerData: A MUXSDKCustomerData object with player,
+///   video, and view metadata
 + (void)videoChangeForPlayer:(nonnull NSString *)name
             withCustomerData:(nullable MUXSDKCustomerData *)customerData;
 
-/*!
- @method      videoChangeForPlayer:withVideoData:
- @abstract    Signals that a player is now playing a different video.
- @param       name The name of the player to update
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @discussion  Use this method to signal that the player is now playing a new video. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should include all desired keys, not just those keys that are specific to this video. If the name of the player provided was not previously initialized, an exception will be raised.
-
- */
-+ (void)videoChangeForPlayer:(nonnull NSString *)name
-               withVideoData:(nullable MUXSDKCustomerVideoData *)videoData __attribute__((deprecated("Please migrate to videoChangeForPlayer:withCustomerData:")));
-
-/*!
- @method      videoChangeForPlayer:withPlayerData:withVideoData
- @abstract    Signals that a player is now playing a different video.
- @param       name The name of the player to update
- @param       playerData A MUXSDKCustomerPlayerData object with video metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @discussion  Use this method to signal that the player is now playing a new video. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should include all desired keys, not just those keys that are specific to this video. If the name of the player provided was not previously initialized, an exception will be raised.
-
- */
-+ (void)videoChangeForPlayer:(nonnull NSString *)name
-              withPlayerData:(nullable MUXSDKCustomerPlayerData *)playerData
-               withVideoData:(nullable MUXSDKCustomerVideoData *)videoData __attribute__((deprecated("Please migrate to videoChangeForPlayer:withCustomerData:")));
-
-/*!
- @method      videoChangeForPlayer:withPlayerData:withVideoData:viewData:
- @abstract    Signals that a player is now playing a different video.
- @param       name The name of the player to update
- @param       playerData A MUXSDKCustomerPlayerData object with video metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @param       viewData A MUXSDKCustomerViewData object with view metadata
- @discussion  Use this method to signal that the player is now playing a new video. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should include all desired keys, not just those keys that are specific to this video. If the name of the player provided was not previously initialized, an exception will be raised.
-
- */
-+ (void)videoChangeForPlayer:(nonnull NSString *)name
-              withPlayerData:(nullable MUXSDKCustomerPlayerData *)playerData
-               withVideoData:(nullable MUXSDKCustomerVideoData *)videoData
-                    viewData:(nullable MUXSDKCustomerViewData *)viewData __attribute__((deprecated("Please migrate to videoChangeForPlayer:withCustomerData:")));
-
 #pragma mark - Program Change
 
-/*!
- @method      programChangeForPlayer:withCustomerData:
- @abstract    Signals that a player is now playing a different video of a playlist; or a different program of a live stream
- @param       name The name of the player to update
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @discussion  Use this method to signal that the player is now playing a differnt video of a playlist, or a different program of a live stream. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should include all desired keys, not just those keys that are specific to this video. If the name of the player provided was not previously initialized, an exception will be raised.
- */
+/// Signals that a player is now playing a different video
+/// of a playlist; or a different program of a live stream
+///
+/// Use this method to signal that the player is now playing
+/// a differnt video of a playlist, or a different program
+/// of a live stream. The player name provided must been
+/// passed as the name in a monitorPlayer:withPlayerName:andConfig:
+/// call. The config provided should match the specifications
+/// in the Mux docs at https://docs.mux.com and should include
+/// all desired keys, not just those keys that are specific
+/// to this video. If the name of the player provided was
+/// not previously initialized, an exception will be raised.
+/// - Parameters:
+///   - name: The name of the player to update
+///   - customerData: A MUXSDKCustomerData object with player,
+///   video, and view metadata
 + (void)programChangeForPlayer:(nonnull NSString *)name
               withCustomerData:(nullable MUXSDKCustomerData *)customerData;
 
-/*!
- @method      programChangeForPlayer:withVideoData:
- @abstract    Signals that a player is now playing a different video of a playlist; or a different program of a live stream
- @param       name The name of the player to update
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @discussion  Use this method to signal that the player is now playing a differnt video of a playlist, or a different program of a live stream. The player name provided must been passed as the name in a monitorPlayer:withPlayerName:andConfig: call. The config provided should match the specifications in the Mux docs at https://docs.mux.com and should include all desired keys, not just those keys that are specific to this video. If the name of the player provided was not previously initialized, an exception will be raised.
- */
-+ (void)programChangeForPlayer:(nonnull NSString *)name
-                 withVideoData:(nullable MUXSDKCustomerVideoData *)videoData __attribute__((deprecated("Please migrate to programChangeForPlayer:withCustomerData:")));
-
 #pragma mark - Custom Data
 
-/*!
- @method      setCustomerData:forPlayer:
- @abstract    allows customerData to be set or updated for the player
- @param       name The name of the player to update
- @param       customerData A MUXSDKCustomerData object with player, video, and view metadata
- @discussion  Use this method after you have already initialized the Mux SDK at any time before the player has been destroyed.
- */
-+ (void)setCustomerData:(nullable MUXSDKCustomerData *)customerData 
+/// Allows customerData to be set or updated for the player
+///
+/// Use this method after you have already initialized the
+/// Mux SDK at any time before the player has been destroyed.
+/// - Parameters:
+///   - customerData: A MUXSDKCustomerData object with player,
+///   video, and view metadata
+///   - name: The name of the player to update
++ (void)setCustomerData:(nullable MUXSDKCustomerData *)customerData
               forPlayer:(nonnull NSString *)name;
-
-/*!
- @method      updateCustomerData:forPlayer:withPlayerData:withVideoData
- @abstract    allows videoData to be set or updated for the player
- @param       name The name of the player to update
- @param       playerData A MUXSDKCustomerPlayerData object with player metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @discussion  Use this method after you have already initialized the Mux SDK at any time before the player has been destroyed. Pass in either videoData or playerData.
- */
-+ (void)updateCustomerDataForPlayer:(nonnull NSString *)name 
-                     withPlayerData:(nullable MUXSDKCustomerPlayerData *)playerData
-                      withVideoData:(nullable MUXSDKCustomerVideoData *)videoData __attribute__((deprecated("Please migrate to setCustomerData:forPlayer:")));
-
-/*!
- @method      updateCustomerData:forPlayer:withPlayerData:withVideoData:viewData:
- @abstract    allows videoData to be set or updated for the player
- @param       name The name of the player to update
- @param       playerData A MUXSDKCustomerPlayerData object with video metadata
- @param       videoData A MUXSDKCustomerVideoData object with video metadata
- @param       viewData A MUXSDKCustomerViewData object with view metadata
- @discussion  Use this method after you have already initialized the Mux SDK at any time before the player has been destroyed. Pass in either videoData, playerData, or viewData.
- */
-+ (void)updateCustomerDataForPlayer:(nonnull NSString *)name 
-                     withPlayerData:(nullable MUXSDKCustomerPlayerData *)playerData
-                      withVideoData:(nullable MUXSDKCustomerVideoData *)videoData 
-                           viewData: (nullable MUXSDKCustomerViewData *) viewData __attribute__((deprecated("Please migrate to setCustomerData:forPlayer:")));
 
 #pragma mark - Orientation Change
 
@@ -538,19 +376,25 @@ __attribute__((deprecated("Please migrate to monitorAVPlayerLayer:withPlayerName
 @param       name The name of the player to update
 @param       orientation A MUXSDKViewOrientation enum value representing if the view has changed to portrait or landscape
 */
-+ (void) orientationChangeForPlayer:(nonnull NSString *) name  
-                    withOrientation:(MUXSDKViewOrientation) orientation;
+
+/// Notifies the Mux SDK that the view's orientation has changed.
+/// - Parameters:
+///   - name: The name of the player to update
+///   - orientation: A MUXSDKViewOrientation enum value
+///   representing if the view has changed to portrait or
+///   landscape
++ (void)orientationChangeForPlayer:(nonnull NSString *)name
+                   withOrientation:(MUXSDKViewOrientation)orientation;
 
 #pragma mark - Error Dispatch
 
-/*!
-@method      dispatchError:withMessage:forPlayer
-@abstract    Dispatches an error with the specified error code and message for the given player
-@param       code The error code in string format
-@param       message The error message in string format
-@param       name The name of the player
-*/
-+ (void)dispatchError:(nonnull NSString *)code 
+/// Dispatches an error with the specified error code and
+/// message for the given player
+/// - Parameters:
+///   - code: The error code in string format
+///   - message: The error message in string format
+///   - name: The name of the player
++ (void)dispatchError:(nonnull NSString *)code
           withMessage:(nonnull NSString *)message
             forPlayer:(nonnull NSString *)name;
 

--- a/Sources/MUXSDKStatsObjc/MUXSDKStats.m
+++ b/Sources/MUXSDKStatsObjc/MUXSDKStats.m
@@ -169,34 +169,6 @@ static MUXSDKCustomerViewerData *_customerViewerData;
                                                    customerData:(nonnull MUXSDKCustomerData *)customerData
                                          automaticErrorTracking:(BOOL)automaticErrorTracking
                                          beaconCollectionDomain:(nullable NSString *)collectionDomain {
-    return [self monitorAVPlayerViewController:player
-                                withPlayerName:name
-                                  customerData:customerData
-                        automaticErrorTracking:automaticErrorTracking
-                        beaconCollectionDomain:collectionDomain
-                                  beaconDomain:nil];
-}
-
-// Legacy deprecated implementation
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
-                                                 withPlayerName:(nonnull NSString *)name
-                                                   customerData:(nonnull MUXSDKCustomerData *)customerData
-                                         automaticErrorTracking:(BOOL)automaticErrorTracking
-                                                   beaconDomain:(nullable NSString *)domain {
-    return [self monitorAVPlayerViewController:player
-                                withPlayerName:name
-                                  customerData:customerData
-                        automaticErrorTracking:automaticErrorTracking
-                        beaconCollectionDomain:nil
-                                  beaconDomain:domain];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
-                                                 withPlayerName:(nonnull NSString *)name
-                                                   customerData:(nonnull MUXSDKCustomerData *)customerData
-                                         automaticErrorTracking:(BOOL)automaticErrorTracking
-                                         beaconCollectionDomain:(nullable NSString *)collectionDomain
-                                                   beaconDomain:(nullable NSString *)domain {
     MUXSDKCustomerViewerData *viewerData = [customerData customerViewerData];
     if (viewerData != nil) {
         _customerViewerData = viewerData;
@@ -231,8 +203,6 @@ static MUXSDKCustomerViewerData *_customerViewerData;
         
         if (collectionDomain != nil && collectionDomain.length > 0) {
             [MUXSDKCore setBeaconCollectionDomain:collectionDomain forPlayer:name];
-        } else if (domain != nil && domain.length > 0) {
-            [MUXSDKCore setBeaconDomain:domain forPlayer:name];
         }
         [MUXSDKCore setDeviceId:[MUXSDKStats getUUIDString] forPlayer:name];
         
@@ -278,59 +248,6 @@ static MUXSDKCustomerViewerData *_customerViewerData;
                                   customerData:customerData
                         automaticErrorTracking:true
                         beaconCollectionDomain:nil];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
-                                                 withPlayerName:(nonnull NSString *)name
-                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData {
-    return [self monitorAVPlayerViewController:player
-                                withPlayerName:name
-                                    playerData:playerData
-                                     videoData:videoData
-                                      viewData:nil
-                        automaticErrorTracking:true];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
-                                                 withPlayerName:(nonnull NSString *)name
-                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                                       viewData:(nullable MUXSDKCustomerViewData *)viewData {
-    return [self monitorAVPlayerViewController:player
-                                withPlayerName:name
-                                    playerData:playerData
-                                     videoData:videoData
-                                      viewData:viewData
-                        automaticErrorTracking:true];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
-                                                 withPlayerName:(nonnull NSString *)name
-                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                         automaticErrorTracking:(BOOL) automaticErrorTracking {
-    return [self monitorAVPlayerViewController:player
-                         withPlayerName:name
-                             playerData:playerData
-                              videoData:videoData
-                               viewData:nil
-                 automaticErrorTracking:automaticErrorTracking];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerViewController:(nonnull AVPlayerViewController *)player
-                                                 withPlayerName:(nonnull NSString *)name
-                                                     playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                                      videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                                       viewData:(nullable MUXSDKCustomerViewData *)viewData
-                                         automaticErrorTracking:(BOOL) automaticErrorTracking {
-    MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:playerData
-                                                                                    videoData:videoData
-                                                                                     viewData:viewData];
-    return [self monitorAVPlayerViewController:player
-                                withPlayerName:name
-                                  customerData:customerData
-                        automaticErrorTracking:automaticErrorTracking];
 }
 
 + (void)updateAVPlayerViewController:(nonnull AVPlayerViewController *)player withPlayerName:(nonnull NSString *)name {
@@ -468,59 +385,6 @@ static MUXSDKCustomerViewerData *_customerViewerData;
                        withPlayerName:name
                          customerData:customerData
                automaticErrorTracking:true];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
-                                        withPlayerName:(nonnull NSString *)name
-                                            playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                             videoData:(nullable MUXSDKCustomerVideoData *)videoData {
-    return [self monitorAVPlayerLayer:player
-                       withPlayerName:name
-                           playerData:playerData
-                            videoData:videoData
-                             viewData:nil
-               automaticErrorTracking:true];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
-                                        withPlayerName:(nonnull NSString *)name
-                                            playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                             videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                              viewData:(nullable MUXSDKCustomerViewData *)viewData {
-    return [self monitorAVPlayerLayer:player
-                       withPlayerName:name
-                           playerData:playerData
-                            videoData:videoData
-                             viewData:viewData
-               automaticErrorTracking:true];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable) monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
-                                         withPlayerName:(nonnull NSString *)name
-                                             playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                              videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                 automaticErrorTracking:(BOOL) automaticErrorTracking {
-    return [self monitorAVPlayerLayer:player
-                       withPlayerName:name
-                           playerData:playerData
-                            videoData:videoData
-                             viewData:nil
-               automaticErrorTracking:automaticErrorTracking];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable) monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
-                                         withPlayerName:(nonnull NSString *)name
-                                             playerData:(nonnull MUXSDKCustomerPlayerData *)playerData
-                                              videoData:(nullable MUXSDKCustomerVideoData *)videoData
-                                               viewData:(nullable MUXSDKCustomerViewData *)viewData
-                                 automaticErrorTracking:(BOOL) automaticErrorTracking {
-    MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:playerData
-                                                                                    videoData:videoData
-                                                                                     viewData:viewData];
-    return [self monitorAVPlayerLayer:player
-                       withPlayerName:name
-                         customerData:customerData
-               automaticErrorTracking:automaticErrorTracking];
 }
 
 + (void)updateAVPlayerLayer:(AVPlayerLayer *)player withPlayerName:(NSString *)name {
@@ -714,22 +578,6 @@ static MUXSDKCustomerViewerData *_customerViewerData;
     }
 }
 
-+ (void)videoChangeForPlayer:(nonnull NSString *)name  withPlayerData:(nullable MUXSDKCustomerPlayerData *)playerData withVideoData:(nullable MUXSDKCustomerVideoData *)videoData viewData: (nullable MUXSDKCustomerViewData *) viewData {
-    MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:playerData videoData:videoData viewData:viewData];
-    [self videoChangeForPlayer:name withCustomerData:customerData];
-}
-
-+ (void)videoChangeForPlayer:(nonnull NSString *)name withPlayerData:(nullable MUXSDKCustomerPlayerData *)playerData withVideoData:(nullable MUXSDKCustomerVideoData *)videoData {
-    MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:playerData videoData:videoData viewData:nil];
-    [self videoChangeForPlayer:name withCustomerData:customerData];
-}
-
-+ (void)videoChangeForPlayer:(nonnull NSString *)name withVideoData:(nullable MUXSDKCustomerVideoData *)videoData {
-    MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] init];
-    customerData.customerVideoData = videoData;
-    [self videoChangeForPlayer:name withCustomerData:customerData];
-}
-
 #pragma mark Program Change
 
 + (void)programChangeForPlayer:(nonnull NSString *)name
@@ -739,12 +587,6 @@ static MUXSDKCustomerViewerData *_customerViewerData;
     if (player) {
         [player programChangedForPlayer];
     }
-}
-
-+ (void)programChangeForPlayer:(nonnull NSString *)name
-                 withVideoData:(nullable MUXSDKCustomerVideoData *)videoData {
-    MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:nil videoData:videoData viewData:nil];
-    [self programChangeForPlayer:name withCustomerData:customerData];
 }
 
 + (void)setAutomaticVideoChange:(NSString *)name enabled:(Boolean)enabled {

--- a/Sources/MUXSDKStatsObjc/MUXSDKStats.m
+++ b/Sources/MUXSDKStatsObjc/MUXSDKStats.m
@@ -276,35 +276,7 @@ static MUXSDKCustomerViewerData *_customerViewerData;
                                         withPlayerName:(nonnull NSString *)name
                                           customerData:(nonnull MUXSDKCustomerData *)customerData
                                 automaticErrorTracking:(BOOL)automaticErrorTracking
-                                          beaconCollectionDomain:(nullable NSString *)collectionDomain {
-    return [self monitorAVPlayerLayer:player
-                       withPlayerName:name
-                         customerData:customerData
-               automaticErrorTracking:automaticErrorTracking
-               beaconCollectionDomain:collectionDomain
-                         beaconDomain:nil];
-}
-
-// Deprecated: Legacy beacon domain implementation
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
-                                        withPlayerName:(nonnull NSString *)name
-                                          customerData:(nonnull MUXSDKCustomerData *)customerData
-                                automaticErrorTracking:(BOOL)automaticErrorTracking
-                                          beaconDomain:(nullable NSString *)domain {
-    return [self monitorAVPlayerLayer:player
-                       withPlayerName:name
-                         customerData:customerData
-               automaticErrorTracking:automaticErrorTracking
-               beaconCollectionDomain:nil
-                         beaconDomain:domain];
-}
-
-+ (MUXSDKPlayerBinding *_Nullable)monitorAVPlayerLayer:(nonnull AVPlayerLayer *)player
-                                        withPlayerName:(nonnull NSString *)name
-                                          customerData:(nonnull MUXSDKCustomerData *)customerData
-                                automaticErrorTracking:(BOOL)automaticErrorTracking
-                                beaconCollectionDomain:(nullable NSString *)collectionDomain
-                                          beaconDomain:(nullable NSString *)domain {
+                                beaconCollectionDomain:(nullable NSString *)collectionDomain {
     MUXSDKCustomerViewerData *viewerData = [customerData customerViewerData];
     if (viewerData != nil) {
         _customerViewerData = viewerData;
@@ -337,8 +309,6 @@ static MUXSDKCustomerViewerData *_customerViewerData;
         [newBinding setAutomaticErrorTracking:automaticErrorTracking];
         if (collectionDomain != nil && collectionDomain.length > 0) {
             [MUXSDKCore setBeaconCollectionDomain:collectionDomain forPlayer:name];
-        } else if (domain != nil && domain.length > 0) {
-            [MUXSDKCore setBeaconDomain:domain forPlayer:name];
         }
         [MUXSDKCore setDeviceId:[MUXSDKStats getUUIDString] forPlayer:name];
 

--- a/Tests/MUXSDKStatsObjcTests/MUXSDKStatsTests.m
+++ b/Tests/MUXSDKStatsObjcTests/MUXSDKStatsTests.m
@@ -195,7 +195,7 @@ static NSString *Z = @"Z";
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerViewController to return a playerBinding");
     [customerViewData setViewSessionId:@"bar"];
-    [MUXSDKStats videoChangeForPlayer:playName withPlayerData:customerPlayerData withVideoData:nil viewData:customerViewData];
+    [MUXSDKStats videoChangeForPlayer:playName withCustomerData:customerData];
     NSArray *expectedEventTypes = @[MUXSDKPlaybackEventViewInitEventType,
                                     MUXSDKDataEventType,
                                     MUXSDKPlaybackEventPlayerReadyEventType,
@@ -219,7 +219,7 @@ static NSString *Z = @"Z";
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerViewController to return a playerBinding");
     [customerVideoData setVideoTitle:@"56789"];
-    [MUXSDKStats videoChangeForPlayer:playName withVideoData:customerVideoData];
+    [MUXSDKStats videoChangeForPlayer:playName withCustomerData:customerData];
     NSArray *expectedEventTypes = @[MUXSDKPlaybackEventViewInitEventType,
                                     MUXSDKDataEventType,
                                     MUXSDKPlaybackEventPlayerReadyEventType,
@@ -259,8 +259,10 @@ static NSString *Z = @"Z";
     // Change video metadata
     MUXSDKCustomerVideoData *newCustomerVideoData = [[MUXSDKCustomerVideoData alloc] init];
     [newCustomerVideoData setVideoTitle:@"56789"];
+    MUXSDKCustomerData *newCustomerData = [[MUXSDKCustomerData alloc] init];
+    newCustomerData.customerVideoData = newCustomerVideoData;
     // It is required to call videoChangeForPlayer: immediately before telling the player which new source to play.
-    [MUXSDKStats videoChangeForPlayer:playName withVideoData:newCustomerVideoData];
+    [MUXSDKStats videoChangeForPlayer:playName withCustomerData:newCustomerData];
     NSURL* videoURL = [NSURL URLWithString:@"https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"];
     AVPlayerItem *item = [AVPlayerItem playerItemWithURL:videoURL];
     [controller.player replaceCurrentItemWithPlayerItem:item];
@@ -313,7 +315,7 @@ static NSString *Z = @"Z";
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerLayer to return a playerBinding");
     [customerViewData setViewSessionId:@"bar"];
-    [MUXSDKStats videoChangeForPlayer:playName withPlayerData:customerPlayerData withVideoData:nil viewData:customerViewData];
+    [MUXSDKStats videoChangeForPlayer:playName withCustomerData:customerData];
     NSArray *expectedEventTypes = @[MUXSDKPlaybackEventViewInitEventType,
                                     MUXSDKDataEventType,
                                     MUXSDKPlaybackEventPlayerReadyEventType,
@@ -337,7 +339,7 @@ static NSString *Z = @"Z";
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerLayer to return a playerBinding");
     [customerVideoData setVideoTitle:@"56789"];
-    [MUXSDKStats videoChangeForPlayer:playName withVideoData:customerVideoData];
+    [MUXSDKStats videoChangeForPlayer:playName withCustomerData:customerData];
     NSArray *expectedEventTypes = @[MUXSDKPlaybackEventViewInitEventType,
                                     MUXSDKDataEventType,
                                     MUXSDKPlaybackEventPlayerReadyEventType,
@@ -377,8 +379,9 @@ static NSString *Z = @"Z";
     // Change video metadata
     MUXSDKCustomerVideoData *newCustomerVideoData = [[MUXSDKCustomerVideoData alloc] init];
     [newCustomerVideoData setVideoTitle:@"56789"];
+    customerData.customerVideoData = newCustomerVideoData;
     // It is required to call videoChangeForPlayer: immediately before telling the player which new source to play.
-    [MUXSDKStats videoChangeForPlayer:playName withVideoData:newCustomerVideoData];
+    [MUXSDKStats videoChangeForPlayer:playName withCustomerData:customerData];
     NSURL* videoURL = [NSURL URLWithString:@"https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"];
     AVPlayerItem *item = [AVPlayerItem playerItemWithURL:videoURL];
     [controller.player replaceCurrentItemWithPlayerItem:item];
@@ -431,7 +434,7 @@ static NSString *Z = @"Z";
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerViewController to return a playerBinding");
     [customerVideoData setVideoTitle:@"56789"];
-    [MUXSDKStats programChangeForPlayer:playName withVideoData:customerVideoData];
+    [MUXSDKStats programChangeForPlayer:playName withCustomerData:customerData];
     NSArray *expectedEventTypes = @[MUXSDKPlaybackEventViewInitEventType,
                                     MUXSDKDataEventType,
                                     MUXSDKPlaybackEventPlayerReadyEventType,


### PR DESCRIPTION
This PR also converts the inline API docs to the docc format. Down the road we should be able to generate static documentation using the Xcode documentation compiler.