### PR TITLE
fix: use right BOOL type

### DIFF
--- a/Sources/MUXSDKStatsObjc/MUXSDKStats.h
+++ b/Sources/MUXSDKStatsObjc/MUXSDKStats.h
@@ -312,7 +312,7 @@
 ///   - enabled: Boolean indicating if automatic video change
 ///   is enabled or not
 + (void)setAutomaticVideoChange:(nonnull NSString *)name
-                        enabled:(Boolean)enabled;
+                        enabled:(BOOL)enabled;
 
 #pragma mark - Manual Video Change
 

--- a/Sources/MUXSDKStatsObjc/MUXSDKStats.m
+++ b/Sources/MUXSDKStatsObjc/MUXSDKStats.m
@@ -240,7 +240,7 @@ static MUXSDKCustomerViewerData *_customerViewerData;
     return [self monitorAVPlayerViewController:player
                                 withPlayerName:name
                                   customerData:customerData
-                        automaticErrorTracking:true
+                        automaticErrorTracking:YES
                         beaconCollectionDomain:nil];
 }
 
@@ -348,7 +348,7 @@ static MUXSDKCustomerViewerData *_customerViewerData;
     return [self monitorAVPlayerLayer:player
                        withPlayerName:name
                          customerData:customerData
-               automaticErrorTracking:true];
+               automaticErrorTracking:YES];
 }
 
 + (void)updateAVPlayerLayer:(AVPlayerLayer *)player withPlayerName:(NSString *)name {
@@ -381,7 +381,7 @@ static MUXSDKCustomerViewerData *_customerViewerData;
                   withPlayerName:name
                  fixedPlayerSize:fixedPlayerSize
                     customerData:customerData
-          automaticErrorTracking:true
+          automaticErrorTracking:YES
           beaconCollectionDomain:nil];
 }
 
@@ -558,7 +558,7 @@ static MUXSDKCustomerViewerData *_customerViewerData;
     }
 }
 
-+ (void)setAutomaticVideoChange:(NSString *)name enabled:(Boolean)enabled {
++ (void)setAutomaticVideoChange:(NSString *)name enabled:(BOOL)enabled {
     MUXSDKPlayerBinding *player = [_viewControllers valueForKey:name];
     if (player) {
         [player setAutomaticVideoChange:enabled];


### PR DESCRIPTION
Changes `MUXSDKStats` to use the conventionally standard Objective-C `BOOL` type.