### PR TITLE
fix: tear down view on hard application termination

### DIFF
--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -142,7 +142,11 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleRenditionChange:) name:RenditionChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleAVPlayerError:) name:AVPlayerItemNewErrorLogEntryNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleConnectionTypeDetected:) name:@"com.mux.connection-type-detected" object:nil];
-    
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleApplicationWillTerminate:)
+                                                 name:UIApplicationWillTerminateNotification
+                                               object:nil];
     //
     // dylanjhaveri
     // See MUXSDKConnection.m for the tvos shortcoming
@@ -184,6 +188,13 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
             [MUXSDKCore dispatchGlobalDataEvent:dataEvent];
         }
     });
+}
+
+- (void)handleApplicationWillTerminate:(NSNotification *)notification {
+    [self dispatchViewEnd];
+    [self stopMonitoringAVPlayerItem];
+
+    [MUXSDKCore destroyPlayer:self.name];
 }
 
 # pragma mark AVPlayerItemAccessLog
@@ -391,7 +402,7 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
         if (_didTriggerManualVideoChange) {
             _didTriggerManualVideoChange = false;
         }
-//        NSLog(@"%s: Dispatching View End", __PRETTY_FUNCTION__);
+        
         [self dispatchViewEnd];
         [self stopMonitoringAVPlayerItem];
         
@@ -471,7 +482,6 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     [self safelyRemovePlayerItemObserverForKeyPath:@"playbackBufferEmpty"];
     _playerItem = nil;
     if (!_isAdPlaying) {
-//        NSLog(@"%s: MUXSDKCore destroyPlayer", __PRETTY_FUNCTION__);
         [MUXSDKCore destroyPlayer: _name];
     }
 }


### PR DESCRIPTION
* dispatch a viewend automatically and tear down player monitoring when the application shuts down
* remove commented out log lines