### PR TITLE
build: add xcconfig, to simplify version updates

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,6 +12,7 @@ steps:
   - wait
   - command: "buildkite-agent artifact download XCFramework/MUXSDKStats.xcframework.zip XCFramework && ./scripts/run-tests-swift-package-manager-ventura.sh"
     label: ":swift: Test Swift Package Manager Example"
+    branches: "releases/*"
     retry:
       automatic: true
   - wait
@@ -22,6 +23,7 @@ steps:
   - wait
   - command: "buildkite-agent artifact download XCFramework/MUXSDKStats.xcframework.zip XCFramework && ./scripts/run-tests-cocoapods-ventura.sh"
     label: ":cocoapods: Test Cocoapods Example"
+    branches: "releases/*"
     retry:
       automatic: true
   - wait

--- a/MUXSDKStats/BuildConfiguration/MUXSDKStats.xcconfig
+++ b/MUXSDKStats/BuildConfiguration/MUXSDKStats.xcconfig
@@ -6,5 +6,8 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 //
+// The names of the xcconfig files correspond to the target
+// they are intended for, excluding the MUXSDKStatsBase
+// which is where configs common to all targets are placed.
 
 #include "MUXSDKStatsBase.xcconfig"

--- a/MUXSDKStats/BuildConfiguration/MUXSDKStats.xcconfig
+++ b/MUXSDKStats/BuildConfiguration/MUXSDKStats.xcconfig
@@ -2,9 +2,9 @@
 //  MUXSDKStats.xcconfig
 //  MUXSDKStats
 //
-
+//
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
+//
 
-MARKETING_VERSION = 4.1.1
-CURRENT_PROJECT_VERSION = 1
+#include "MUXSDKStatsBase.xcconfig"

--- a/MUXSDKStats/BuildConfiguration/MUXSDKStatsBase.xcconfig
+++ b/MUXSDKStats/BuildConfiguration/MUXSDKStatsBase.xcconfig
@@ -1,0 +1,11 @@
+//
+//  MUXSDKStatsBase.xcconfig
+//  MUXSDKStats
+//
+//
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+//
+
+MARKETING_VERSION = 4.1.1
+CURRENT_PROJECT_VERSION = 1

--- a/MUXSDKStats/BuildConfiguration/MUXSDKStatsBase.xcconfig
+++ b/MUXSDKStats/BuildConfiguration/MUXSDKStatsBase.xcconfig
@@ -6,6 +6,9 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 //
+// The names of the xcconfig files correspond to the target
+// they are intended for, excluding the MUXSDKStatsBase
+// which is where configs common to all targets are placed.
 
 MARKETING_VERSION = 4.1.1
 CURRENT_PROJECT_VERSION = 1

--- a/MUXSDKStats/BuildConfiguration/MUXSDKStatsTv.xcconfig
+++ b/MUXSDKStats/BuildConfiguration/MUXSDKStatsTv.xcconfig
@@ -6,5 +6,8 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 //
+// The names of the xcconfig files correspond to the target
+// they are intended for, excluding the MUXSDKStatsBase
+// which is where configs common to all targets are placed.
 
 #include "MUXSDKStatsBase.xcconfig"

--- a/MUXSDKStats/BuildConfiguration/MUXSDKStatsTv.xcconfig
+++ b/MUXSDKStats/BuildConfiguration/MUXSDKStatsTv.xcconfig
@@ -1,0 +1,10 @@
+//
+//  MUXSDKStatsTv.xcconfig
+//  MUXSDKStats
+//
+//
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+//
+
+#include "MUXSDKStatsBase.xcconfig"

--- a/MUXSDKStats/BuildConfiguration/MUXSDKStatsVision.xcconfig
+++ b/MUXSDKStats/BuildConfiguration/MUXSDKStatsVision.xcconfig
@@ -1,0 +1,11 @@
+//
+//  MUXSDKStatsVision.xcconfig
+//  MUXSDKStats
+//
+//
+//
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+//
+
+#include "MUXSDKStatsBase.xcconfig"

--- a/MUXSDKStats/BuildConfiguration/MUXSDKStatsVision.xcconfig
+++ b/MUXSDKStats/BuildConfiguration/MUXSDKStatsVision.xcconfig
@@ -7,5 +7,8 @@
 // Configuration settings file format documentation can be found at:
 // https://help.apple.com/xcode/#/dev745c5c974
 //
+// The names of the xcconfig files correspond to the target
+// they are intended for, excluding the MUXSDKStatsBase
+// which is where configs common to all targets are placed.
 
 #include "MUXSDKStatsBase.xcconfig"

--- a/MUXSDKStats/MUXSDKStats.xcodeproj/project.pbxproj
+++ b/MUXSDKStats/MUXSDKStats.xcodeproj/project.pbxproj
@@ -34,6 +34,12 @@
 		1915A2102CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */; };
 		1915A2112CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */; };
 		1915A2122CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */; };
+		1915A2262CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A2252CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig */; };
+		1915A2272CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A2252CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig */; };
+		1915A2282CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A2252CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig */; };
+		1915A22A2CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A2292CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig */; };
+		1915A22B2CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A2292CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig */; };
+		1915A22C2CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A2292CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig */; };
 		1917D7BC2AB97FBC009654E8 /* MUXSDKStatsTvTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1917D7BB2AB97FBC009654E8 /* MUXSDKStatsTvTests.m */; };
 		1917D7C32AB97FC5009654E8 /* MUXSDKStats.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41E09041DDA8E530028A296 /* MUXSDKStats.framework */; };
 		195800E32B51BD43008BE2EB /* MUXSDKStatsVision.h in Headers */ = {isa = PBXBuildFile; fileRef = 195800E22B51BD43008BE2EB /* MUXSDKStatsVision.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -125,6 +131,9 @@
 		02EB9E2B23E896790007E1CD /* MUXSDKCustomerVideoDataStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MUXSDKCustomerVideoDataStore.h; sourceTree = "<group>"; };
 		02EB9E2C23E896790007E1CD /* MUXSDKCustomerVideoDataStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MUXSDKCustomerVideoDataStore.m; sourceTree = "<group>"; };
 		1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MUXSDKStats.xcconfig; sourceTree = "<group>"; };
+		1915A2252CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MUXSDKStatsBase.xcconfig; sourceTree = "<group>"; };
+		1915A2292CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MUXSDKStatsTv.xcconfig; sourceTree = "<group>"; };
+		1915A22D2CC1C43A0094AA27 /* MUXSDKStatsVision.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MUXSDKStatsVision.xcconfig; sourceTree = "<group>"; };
 		1917D7B92AB97FBC009654E8 /* MUXSDKStatsTvTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MUXSDKStatsTvTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1917D7BB2AB97FBC009654E8 /* MUXSDKStatsTvTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MUXSDKStatsTvTests.m; sourceTree = "<group>"; };
 		195800E02B51BD43008BE2EB /* MUXSDKStats.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MUXSDKStats.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -212,6 +221,17 @@
 			path = Utils;
 			sourceTree = "<group>";
 		};
+		1915A2242CC1C3C70094AA27 /* BuildConfiguration */ = {
+			isa = PBXGroup;
+			children = (
+				1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */,
+				1915A2252CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig */,
+				1915A2292CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig */,
+				1915A22D2CC1C43A0094AA27 /* MUXSDKStatsVision.xcconfig */,
+			);
+			path = BuildConfiguration;
+			sourceTree = "<group>";
+		};
 		1917D7BA2AB97FBC009654E8 /* MUXSDKStatsTvTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -258,6 +278,7 @@
 			isa = PBXGroup;
 			children = (
 				19F2B2562B68731000D5DEA6 /* MUXSDKStatsVision.xctestplan */,
+				1915A2242CC1C3C70094AA27 /* BuildConfiguration */,
 				F4DCACFF1DCA892E0094D94C /* MUXSDKStats */,
 				F4DCAD0A1DCA892E0094D94C /* MUXSDKStatsTests */,
 				F41E09051DDA8E530028A296 /* MUXSDKStatsTv */,
@@ -304,7 +325,6 @@
 				02D28F2F26D0972200D152EF /* MUXSDKCustomerCustomDataStore.h */,
 				02D28F3026D0972200D152EF /* MUXSDKCustomerCustomDataStore.m */,
 				19CC56302BC895CC00464AFA /* PrivacyInfo.xcprivacy */,
-				1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */,
 			);
 			path = MUXSDKStats;
 			sourceTree = "<group>";
@@ -564,6 +584,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				1915A2122CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */,
+				1915A2272CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig in Resources */,
+				1915A22B2CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig in Resources */,
 				19DB618B2BD1E0210048424F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -580,6 +602,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				1915A2112CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */,
+				1915A2262CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig in Resources */,
+				1915A22A2CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig in Resources */,
 				19DB618A2BD1E0200048424F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -589,6 +613,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				1915A2102CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */,
+				1915A2282CC1C3E70094AA27 /* MUXSDKStatsBase.xcconfig in Resources */,
+				1915A22C2CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig in Resources */,
 				19DB61892BD1E01F0048424F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -755,7 +781,7 @@
 		};
 		195800E42B51BD43008BE2EB /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
+			baseConfigurationReference = 1915A22D2CC1C43A0094AA27 /* MUXSDKStatsVision.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -776,6 +802,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Mux, Inc. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -800,7 +827,7 @@
 		};
 		195800E52B51BD43008BE2EB /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
+			baseConfigurationReference = 1915A22D2CC1C43A0094AA27 /* MUXSDKStatsVision.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -824,6 +851,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2024 Mux, Inc. All rights reserved.";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -905,7 +933,7 @@
 		};
 		F41E09091DDA8E530028A296 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
+			baseConfigurationReference = 1915A2292CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -939,7 +967,7 @@
 		};
 		F41E090A1DDA8E530028A296 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
+			baseConfigurationReference = 1915A2292CC1C4240094AA27 /* MUXSDKStatsTv.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Distribution: Mux, Inc (XX95P4Y787)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "Apple Distribution: Mux, Inc (XX95P4Y787)";
@@ -1021,7 +1049,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
@@ -1041,7 +1068,6 @@
 				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1092,7 +1118,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -1111,7 +1136,6 @@
 				);
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 11.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/MUXSDKStats/MUXSDKStats.xcodeproj/project.pbxproj
+++ b/MUXSDKStats/MUXSDKStats.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		02EB9E2E23E896790007E1CD /* MUXSDKCustomerVideoDataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 02EB9E2C23E896790007E1CD /* MUXSDKCustomerVideoDataStore.m */; };
 		02EB9E2F23E896A90007E1CD /* MUXSDKCustomerVideoDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 02EB9E2B23E896790007E1CD /* MUXSDKCustomerVideoDataStore.h */; };
 		02EB9E3023E896F20007E1CD /* MUXSDKCustomerVideoDataStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 02EB9E2C23E896790007E1CD /* MUXSDKCustomerVideoDataStore.m */; };
+		1915A2102CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */; };
+		1915A2112CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */; };
+		1915A2122CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */; };
 		1917D7BC2AB97FBC009654E8 /* MUXSDKStatsTvTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1917D7BB2AB97FBC009654E8 /* MUXSDKStatsTvTests.m */; };
 		1917D7C32AB97FC5009654E8 /* MUXSDKStats.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F41E09041DDA8E530028A296 /* MUXSDKStats.framework */; };
 		195800E32B51BD43008BE2EB /* MUXSDKStatsVision.h in Headers */ = {isa = PBXBuildFile; fileRef = 195800E22B51BD43008BE2EB /* MUXSDKStatsVision.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -121,6 +124,7 @@
 		02EB9E2623E894E70007E1CD /* MUXSDKCustomerPlayerDataStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MUXSDKCustomerPlayerDataStore.m; sourceTree = "<group>"; };
 		02EB9E2B23E896790007E1CD /* MUXSDKCustomerVideoDataStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MUXSDKCustomerVideoDataStore.h; sourceTree = "<group>"; };
 		02EB9E2C23E896790007E1CD /* MUXSDKCustomerVideoDataStore.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MUXSDKCustomerVideoDataStore.m; sourceTree = "<group>"; };
+		1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = MUXSDKStats.xcconfig; sourceTree = "<group>"; };
 		1917D7B92AB97FBC009654E8 /* MUXSDKStatsTvTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MUXSDKStatsTvTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1917D7BB2AB97FBC009654E8 /* MUXSDKStatsTvTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MUXSDKStatsTvTests.m; sourceTree = "<group>"; };
 		195800E02B51BD43008BE2EB /* MUXSDKStats.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MUXSDKStats.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -300,6 +304,7 @@
 				02D28F2F26D0972200D152EF /* MUXSDKCustomerCustomDataStore.h */,
 				02D28F3026D0972200D152EF /* MUXSDKCustomerCustomDataStore.m */,
 				19CC56302BC895CC00464AFA /* PrivacyInfo.xcprivacy */,
+				1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */,
 			);
 			path = MUXSDKStats;
 			sourceTree = "<group>";
@@ -558,6 +563,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1915A2122CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */,
 				19DB618B2BD1E0210048424F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -573,6 +579,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1915A2112CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */,
 				19DB618A2BD1E0200048424F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -581,6 +588,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1915A2102CC064B80094AA27 /* MUXSDKStats.xcconfig in Resources */,
 				19DB61892BD1E01F0048424F /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -747,6 +755,7 @@
 		};
 		195800E42B51BD43008BE2EB /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -773,7 +782,6 @@
 					"@loader_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 4.1.0;
 				MODULEMAP_FILE = "$(SRCROOT)/MUXSDKStatsVision/module.modulemap";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
@@ -792,6 +800,7 @@
 		};
 		195800E52B51BD43008BE2EB /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -821,7 +830,6 @@
 					"@loader_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 4.1.0;
 				MODULEMAP_FILE = "$(SRCROOT)/MUXSDKStatsVision/module.modulemap";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGES = "objective-c objective-c++";
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
@@ -897,6 +905,7 @@
 		};
 		F41E09091DDA8E530028A296 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
@@ -917,7 +926,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.1.0;
 				MODULEMAP_FILE = "$(SRCROOT)/MUXSDKStatsTv/module.modulemap";
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.tvos.MUXSDKStatsTv;
@@ -931,6 +939,7 @@
 		};
 		F41E090A1DDA8E530028A296 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "Apple Distribution: Mux, Inc (XX95P4Y787)";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "Apple Distribution: Mux, Inc (XX95P4Y787)";
@@ -951,7 +960,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.1.0;
 				MODULEMAP_FILE = "$(SRCROOT)/MUXSDKStatsTv/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.tvos.MUXSDKStatsTv;
 				PRODUCT_NAME = MUXSDKStats;
@@ -1112,6 +1120,7 @@
 		};
 		F4DCAD121DCA892E0094D94C /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -1134,7 +1143,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.1.0;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.ios.MUXSDKStats;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1145,6 +1153,7 @@
 		};
 		F4DCAD131DCA892E0094D94C /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1915A20F2CC064B80094AA27 /* MUXSDKStats.xcconfig */;
 			buildSettings = {
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_IDENTITY = "Apple Distribution: Mux, Inc (XX95P4Y787)";
@@ -1168,7 +1177,6 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 4.1.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.mux.stats.ios.MUXSDKStats;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -142,7 +142,11 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleRenditionChange:) name:RenditionChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleAVPlayerError:) name:AVPlayerItemNewErrorLogEntryNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleConnectionTypeDetected:) name:@"com.mux.connection-type-detected" object:nil];
-    
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleApplicationWillTerminate:)
+                                                 name:UIApplicationWillTerminateNotification
+                                               object:nil];
     //
     // dylanjhaveri
     // See MUXSDKConnection.m for the tvos shortcoming
@@ -184,6 +188,13 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
             [MUXSDKCore dispatchGlobalDataEvent:dataEvent];
         }
     });
+}
+
+- (void)handleApplicationWillTerminate:(NSNotification *)notification {
+    [self dispatchViewEnd];
+    [self stopMonitoringAVPlayerItem];
+
+    [MUXSDKCore destroyPlayer:self.name];
 }
 
 # pragma mark AVPlayerItemAccessLog
@@ -391,7 +402,7 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
         if (_didTriggerManualVideoChange) {
             _didTriggerManualVideoChange = false;
         }
-//        NSLog(@"%s: Dispatching View End", __PRETTY_FUNCTION__);
+        
         [self dispatchViewEnd];
         [self stopMonitoringAVPlayerItem];
         
@@ -471,7 +482,6 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     [self safelyRemovePlayerItemObserverForKeyPath:@"playbackBufferEmpty"];
     _playerItem = nil;
     if (!_isAdPlaying) {
-//        NSLog(@"%s: MUXSDKCore destroyPlayer", __PRETTY_FUNCTION__);
         [MUXSDKCore destroyPlayer: _name];
     }
 }

--- a/MUXSDKStats/MUXSDKStats/MUXSDKStats.xcconfig
+++ b/MUXSDKStats/MUXSDKStats/MUXSDKStats.xcconfig
@@ -1,0 +1,10 @@
+//
+//  MUXSDKStats.xcconfig
+//  MUXSDKStats
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+MARKETING_VERSION = 4.1.1
+CURRENT_PROJECT_VERSION = 1

--- a/scripts/create-dynamic-xcframework.sh
+++ b/scripts/create-dynamic-xcframework.sh
@@ -7,6 +7,13 @@ then
     exit 1
 fi
 
+if [[ $(git branch --show-current | sed -E 's/.*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/') == $(git branch --show-current) ]]; then
+    readonly RELEASE_VERSION="4.1.1"
+    echo "▸ Not on a release branch. Falling back to hardcoded release version: $RELEASE_VERSION"
+else
+    readonly RELEASE_VERSION=$(git branch --show-current | sed -E 's/.*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+fi
+
 readonly BUILD_DIR=$PWD/MUXSDKStats/xc
 readonly PROJECT=$PWD/MUXSDKStats/MUXSDKStats.xcodeproj
 readonly TARGET_DIR=$PWD/XCFramework
@@ -44,6 +51,25 @@ xcodebuild clean archive \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
 
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} visionOS slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create visionOS dynamic framework slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying visionOS Slice Version"
+
+visionos_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStatsVision.visionOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${visionos_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ visionOS slice version ${visionos_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: visionOS slice version ${visionos_slice_version} does not match, please update ${FRAMEWORK_NAME} build settings to ${RELEASE_VERSION}"
+    exit 1
+fi
+
 echo "▸ Creating visionOS Simulator archive"
 
 xcodebuild clean archive \
@@ -53,6 +79,25 @@ xcodebuild clean archive \
     -archivePath "$BUILD_DIR/MUXSDKStatsVision.visionOS-simulator.xcarchive" \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
+
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} visionOS Simulator slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create visionOS Simulator dynamic framework slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying visionOS Simulator Slice Version"
+
+visionos_simulator_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStatsVision.visionOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${visionos_simulator_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ visionOS Simulator slice version ${visionos_simulator_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: visionOS Simulator slice version ${visionos_simulator_slice_version} does not match, please update ${FRAMEWORK_NAME} build settings to ${RELEASE_VERSION}"
+    exit 1
+fi
 
 echo "▸ Creating tvOS archive"
 
@@ -64,6 +109,25 @@ xcodebuild clean archive \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
 
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} tvOS slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create tvOS dynamic framework slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying tvOS Slice Version"
+
+tvos_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStatsTv.tvOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${tvos_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ tvOS slice version ${tvos_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: tvOS slice version ${tvos_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString."
+    exit 1
+fi
+
 echo "▸ Creating tvOS Simulator archive"
 
 xcodebuild clean archive \
@@ -73,6 +137,25 @@ xcodebuild clean archive \
     -archivePath "$BUILD_DIR/MUXSDKStatsTv.tvOS-simulator.xcarchive" \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
+
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} tvOS Simulator slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create tvOS Simulator dynamic framework slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying tvOS Simulator Slice Version"
+
+tvos_simulator_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStatsTv.tvOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${tvos_simulator_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ tvOS Simulator slice version ${tvos_simulator_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: tvOS Simulator slice version ${tvos_simulator_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString"
+    exit 1
+fi
 
 echo "▸ Creating iOS archive"
 
@@ -84,6 +167,25 @@ xcodebuild clean archive \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
 
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} iOS slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create iOS dynamic framework slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying iOS Slice Version"
+
+ios_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStats.iOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${ios_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ iOS slice version ${ios_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: iOS slice version ${ios_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString"
+    exit 1
+fi
+
 echo "▸ Creating iOS Simulator archive"
 
 xcodebuild clean archive \
@@ -93,6 +195,25 @@ xcodebuild clean archive \
     -archivePath "$BUILD_DIR/MUXSDKStats.iOS-simulator.xcarchive" \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
+
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} iOS Simulator slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create iOS Simulator dynamic framework slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying iOS Simulator Slice Version"
+
+ios_simulator_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStats.iOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${ios_simulator_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ iOS Simulator slice version ${ios_simulator_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: iOS Simulator slice version ${ios_simulator_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString"
+    exit 1
+fi
 
 echo "▸ Creating Mac Catalyst archive"
 
@@ -104,7 +225,27 @@ xcodebuild clean archive \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES | xcbeautify
 
-echo "▸ Creating ${PACKAGE_NAME}"
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} Mac Catalyst slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create Mac Catalyst dynamic framework slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying Mac Catalyst Slice Version"
+
+# Note: Info.plist is in different location for macOS slices
+mac_catalyst_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStats.macOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Resources/Info.plist)"
+
+if [ "${mac_catalyst_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ Mac Catalyst slice version ${mac_catalyst_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: Mac Catalyst slice version ${mac_catalyst_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString"
+    exit 1
+fi
+
+echo "▸ Creating ${PACKAGE_NAME} Dynamic Framework Multiplatform Bundle"
   
 xcodebuild -create-xcframework \
     -framework "$BUILD_DIR/MUXSDKStatsVision.visionOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
@@ -117,7 +258,7 @@ xcodebuild -create-xcframework \
     -output "${TARGET_DIR}/${PACKAGE_NAME}" | xcbeautify
 
 if [[ $? == 0 ]]; then
-    echo "▸ Successfully created ${FRAMEWORK_NAME} XCFramework at ${TARGET_DIR}"
+    echo -e "\033[01;32m ▸ Successfully created ${PACKAGE_NAME} Dynamic Framework Multiplatform Bundle at ${TARGET_DIR} \033[0m"
 else
     echo -e "\033[1;31m ERROR: Failed to create ${FRAMEWORK_NAME} XCFramework \033[0m"
     exit 1
@@ -127,8 +268,24 @@ echo "▸ Code signing ${PACKAGE_NAME} using ${CODE_SIGNING_CERTIFICATE}"
 
 codesign --timestamp -v --sign "${CODE_SIGNING_CERTIFICATE}" "$TARGET_DIR/$PACKAGE_NAME"
 
-codesign --verify --verbose "${TARGET_DIR}/${PACKAGE_NAME}" 
+if [[ $? == 0 ]]; then
+    echo -e "\033[01;32m ▸ Successfully code signed ${PACKAGE_NAME} \033[0m"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to code sign ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
 
-echo "▸ Deleting Build Directory: ${BUILD_DIR}"
+echo "▸ Verifying ${TARGET_DIR}/${PACKAGE_NAME} code signature"
+
+codesign --verify --verbose "${TARGET_DIR}/${PACKAGE_NAME}"
+
+if [[ $? == 0 ]]; then
+    echo "▸ Verified ${PACKAGE_NAME} code signature"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to verify code signature at ${TARGET_DIR}/${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Deleting old build intermediate products directory: ${BUILD_DIR}"
 
 rm -Rf $BUILD_DIR

--- a/scripts/create-static-xcframework.sh
+++ b/scripts/create-static-xcframework.sh
@@ -259,17 +259,17 @@ else
     exit 1
 fi
 
- echo "▸ Creating ${PACKAGE_NAME} Static Library Multiplatform Bundle"
+echo "▸ Creating ${PACKAGE_NAME} Static Library Multiplatform Bundle"
 
- xcodebuild -create-xcframework \
-      -framework "$BUILD_DIR/MUXSDKStatsVision.visionOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
-      -framework "$BUILD_DIR/MUXSDKStatsVision.visionOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
-      -framework "$BUILD_DIR/MUXSDKStatsTv.tvOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
-      -framework "$BUILD_DIR/MUXSDKStatsTv.tvOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
-      -framework "$BUILD_DIR/MUXSDKStats.iOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
-      -framework "$BUILD_DIR/MUXSDKStats.iOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
-      -framework "$BUILD_DIR/MUXSDKStats.macOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
-      -output "$TARGET_DIR/MUXSDKStats.xcframework" | xcbeautify
+xcodebuild -create-xcframework \
+    -framework "$BUILD_DIR/MUXSDKStatsVision.visionOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
+    -framework "$BUILD_DIR/MUXSDKStatsVision.visionOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
+    -framework "$BUILD_DIR/MUXSDKStatsTv.tvOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
+    -framework "$BUILD_DIR/MUXSDKStatsTv.tvOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
+    -framework "$BUILD_DIR/MUXSDKStats.iOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
+    -framework "$BUILD_DIR/MUXSDKStats.iOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
+    -framework "$BUILD_DIR/MUXSDKStats.macOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
+    -output "$TARGET_DIR/MUXSDKStats.xcframework" | xcbeautify
 
 if [[ $? == 0 ]]; then
     echo -e "\033[01;32m ▸ Successfully created ${PACKAGE_NAME} Static Library Multiplatform Bundle at ${TARGET_DIR} \033[0m"

--- a/scripts/create-static-xcframework.sh
+++ b/scripts/create-static-xcframework.sh
@@ -7,6 +7,13 @@ then
     exit 1
 fi
 
+if [[ $(git branch --show-current | sed -E 's/.*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/') == $(git branch --show-current) ]]; then
+    readonly RELEASE_VERSION="4.1.1"
+    echo "▸ Not on a release branch. Falling back to hardcoded release version: $RELEASE_VERSION"
+else
+    readonly RELEASE_VERSION=$(git branch --show-current | sed -E 's/.*v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+fi
+
 readonly BUILD_DIR=$PWD/MUXSDKStats/xc
 readonly PROJECT=$PWD/MUXSDKStats/MUXSDKStats.xcodeproj
 readonly TARGET_DIR=$PWD/XCFramework
@@ -46,6 +53,25 @@ xcodebuild clean archive \
     CLANG_ENABLE_MODULES=NO \
     MACH_O_TYPE=staticlib | xcbeautify
 
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} visionOS slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create visionOS static library slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying visionOS Slice Version"
+
+visionos_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStatsVision.visionOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${visionos_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ visionOS slice version ${visionos_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: visionOS slice version ${visionos_slice_version} does not match, please update ${FRAMEWORK_NAME} build settings to ${RELEASE_VERSION}"
+    exit 1
+fi
+
 echo "▸ Creating visionOS Simulator archive"
 
 xcodebuild clean archive \
@@ -56,7 +82,26 @@ xcodebuild clean archive \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
     CLANG_ENABLE_MODULES=NO \
-    MACH_O_TYPE=staticlib | xcbeautify                                                                                                                                 
+    MACH_O_TYPE=staticlib | xcbeautify
+
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} visionOS Simulator slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create visionOS Simulator static library slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying visionOS Simulator Slice Version"
+
+visionos_simulator_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStatsVision.visionOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${visionos_simulator_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ visionOS Simulator slice version ${visionos_simulator_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: visionOS Simulator slice version ${visionos_simulator_slice_version} does not match, please update ${FRAMEWORK_NAME} build settings to ${RELEASE_VERSION}"
+    exit 1
+fi                                                                                                                                 
 
 echo "▸ Creating tvOS archive"
 
@@ -70,6 +115,25 @@ xcodebuild clean archive \
   CLANG_ENABLE_MODULES=NO \
   MACH_O_TYPE=staticlib | xcbeautify
 
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} tvOS slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create tvOS static library slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying tvOS Slice Version"
+
+tvos_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStatsTv.tvOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${tvos_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ tvOS slice version ${tvos_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: tvOS slice version ${tvos_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString."
+    exit 1
+fi
+
 echo "▸ Creating tvOS Simulator archive"
 
 xcodebuild clean archive \
@@ -82,6 +146,27 @@ xcodebuild clean archive \
   CLANG_ENABLE_MODULES=NO \
   MACH_O_TYPE=staticlib | xcbeautify
 
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} tvOS Simulator slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create tvOS Simulator static library slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying tvOS Simulator Slice Version"
+
+tvos_simulator_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStatsTv.tvOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${tvos_simulator_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ tvOS Simulator slice version ${tvos_simulator_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: tvOS Simulator slice version ${tvos_simulator_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString"
+    exit 1
+fi
+
+echo "▸ Creating iOS archive"
+
 xcodebuild clean archive \
   -scheme MUXSDKStats \
   -project $PROJECT \
@@ -91,6 +176,27 @@ xcodebuild clean archive \
   BUILD_LIBRARY_FOR_DISTRIBUTION=YES \
   CLANG_ENABLE_MODULES=NO \
   MACH_O_TYPE=staticlib | xcbeautify
+
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} iOS slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create iOS static library slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying iOS Slice Version"
+
+ios_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStats.iOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${ios_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ iOS slice version ${ios_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: iOS slice version ${ios_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString"
+    exit 1
+fi
+
+echo "▸ Creating iOS Simulator archive"
 
 xcodebuild clean archive \
   -scheme MUXSDKStats \
@@ -102,6 +208,27 @@ xcodebuild clean archive \
   CLANG_ENABLE_MODULES=NO \
   MACH_O_TYPE=staticlib | xcbeautify
 
+if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} iOS Simulator slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create iOS Simulator static library slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying iOS Simulator Slice Version"
+
+ios_simulator_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStats.iOS-simulator.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Info.plist)"
+
+if [ "${ios_simulator_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ iOS Simulator slice version ${ios_simulator_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: iOS Simulator slice version ${ios_simulator_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString"
+    exit 1
+fi
+
+echo "▸ Creating Mac Catalyst archive"
+
 xcodebuild clean archive \
   -scheme MUXSDKStats \
   -project $PROJECT \
@@ -112,7 +239,27 @@ xcodebuild clean archive \
  CLANG_ENABLE_MODULES=NO \
  MACH_O_TYPE=staticlib | xcbeautify
 
- echo "▸ Creating ${PACKAGE_NAME}"
+ if [[ $? == 0 ]]; then
+    echo "▸ Successfully created ${PACKAGE_NAME} Mac Catalyst slice"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to create Mac Catalyst static library slice for ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Verifying Mac Catalyst Slice Version"
+
+# Note: Info.plist is in different location for macOS slices
+mac_catalyst_slice_version="$(plutil -extract CFBundleShortVersionString raw \
+       -o - $BUILD_DIR/MUXSDKStats.macOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework/Resources/Info.plist)"
+
+if [ "${mac_catalyst_slice_version}" == "${RELEASE_VERSION}" ]; then
+    echo "▸ Mac Catalyst slice version ${mac_catalyst_slice_version} matches expected value"
+else
+    echo -e "\033[1;31m ▸ ERROR: Mac Catalyst slice version ${mac_catalyst_slice_version} does not match expected value: ${RELEASE_VERSION}. Please update ${FRAMEWORK_NAME} CFBundleShortVersionString"
+    exit 1
+fi
+
+ echo "▸ Creating ${PACKAGE_NAME} Static Library Multiplatform Bundle"
 
  xcodebuild -create-xcframework \
       -framework "$BUILD_DIR/MUXSDKStatsVision.visionOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
@@ -124,12 +271,36 @@ xcodebuild clean archive \
       -framework "$BUILD_DIR/MUXSDKStats.macOS.xcarchive/Products/Library/Frameworks/MUXSDKStats.framework" \
       -output "$TARGET_DIR/MUXSDKStats.xcframework" | xcbeautify
 
+if [[ $? == 0 ]]; then
+    echo -e "\033[01;32m ▸ Successfully created ${PACKAGE_NAME} Static Library Multiplatform Bundle at ${TARGET_DIR} \033[0m"
+else
+    echo -e "\033[1;31m ERROR: Failed to create ${PACKAGE_NAME} Static Library Multiplatform Bundle \033[0m"
+    exit 1
+fi
+
 echo "▸ Code signing ${PACKAGE_NAME} using ${CODE_SIGNING_CERTIFICATE}"
 
 codesign --timestamp -v --sign "${CODE_SIGNING_CERTIFICATE}" "$TARGET_DIR/$PACKAGE_NAME"
 
-codesign --verify --verbose "${TARGET_DIR}/${PACKAGE_NAME}" 
+if [[ $? == 0 ]]; then
+    echo -e "\033[01;32m ▸ Successfully code signed ${PACKAGE_NAME} \033[0m"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to code sign ${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
 
-echo "▸ Deleting Build Directory: ${BUILD_DIR}"
+echo "▸ Verifying ${TARGET_DIR}/${PACKAGE_NAME} code signature"
+
+codesign --verify --verbose "${TARGET_DIR}/${PACKAGE_NAME}"
+
+if [[ $? == 0 ]]; then
+    echo "▸ Verified ${PACKAGE_NAME} code signature"
+else
+    echo -e "\033[1;31m ▸ ERROR: Failed to verify code signature at ${TARGET_DIR}/${PACKAGE_NAME} \033[0m"
+    exit 1
+fi
+
+echo "▸ Deleting old build intermediate products directory: ${BUILD_DIR}"
 
 rm -Rf $BUILD_DIR
+

--- a/scripts/create-static-xcframework.sh
+++ b/scripts/create-static-xcframework.sh
@@ -16,6 +16,8 @@ readonly PACKAGE_NAME=${FRAMEWORK_NAME}.xcframework
 
 readonly CODE_SIGNING_CERTIFICATE="Apple Distribution: Mux, Inc (XX95P4Y787)"
 
+echo "▸ Current Xcode: $(xcode-select -p)"
+
 readonly XCODE=$(xcodebuild -version | grep Xcode | cut -d " " -f2)
 
 echo "▸ Using Xcode Version: ${XCODE}"


### PR DESCRIPTION
- [x] Add xcconfig for each target, to simplify version updates
- [x] Remove iOS 11 deployment target flags that aren't applicable (and would result in build failures on Xcode 15+ if they were)
- [x] Add Xcode path log to static build script for consistency
- [x] Skip SPM and Cocoapods tests on non-release branches 