### PR TITLE
fix: Missing Source Resolution (and therefore WAB and VQ) in some cases

### DIFF
--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -603,35 +603,15 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
         if (lastEvent) {
             long long transferredBytes = lastEvent.numberOfBytesTransferred;
             NSTimeInterval downloadedDuration = lastEvent.segmentsDownloadedDuration;
-            NSLog(@"findMostRecentAdvertisedBitrateForPlayerItem: last event has transferred bytes %lld", transferredBytes);
-            NSLog(@"findMostRecentAdvertisedBitrateForPlayerItem: last event has duration %f", downloadedDuration);
-//            NSNumber *transferredBits = [NSNumber numberWithFloat: transferredBytes * 8];
             long long transferredBits = transferredBytes * 8;
             double calculatedBitrate = transferredBits / downloadedDuration;
-            NSLog(@"findMostRecentAdvertisedBitrateForPlayerItem: calculated bitrate %f", calculatedBitrate);
-            NSLog(@"findMostRecentAdvertisedBitrateForPlayerItem: calculated bitrate as long %ld", (long)calculatedBitrate);
-            return calculatedBitrate;
+            return (long)calculatedBitrate; // any rounding is fine
         } else {
-            NSLog(@"findMostRecentAdvertisedBitrateForPlayerItem: last event was nil");
+            NSLog(@"findMostRecentAdvertisedBitrateForPlayerItem: no events");
         }
-        return -1;
-
-//        // TODO: This only works if there is a bitrate indicated in the MVP/Media Playlist
-//        //  Do we even want to use this one still
-//        for (int i = 0; i < events.count; i++) {
-//            AVPlayerItemAccessLogEvent *ev = events[i];
-//            double bitrateFromLog = ev.indicatedBitrate;
-//            if (bitrateFromLog > 0) {
-//                recentBitrateEvent = ev;
-//            }
-//        }
     }
     
-//    if (recentBitrateEvent) {
-//        return recentBitrateEvent.indicatedBitrate;
-//    } else {
-//        return -1;
-//    }
+    return -1;
 }
 
 - (nullable NSString *)getURLStringIfAvailableOnAVPlayerItem:(nonnull AVPlayerItem *)item {

--- a/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM.xcodeproj/xcshareddata/xcschemes/MUXSDKStatsExampleSPM.xcscheme
+++ b/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM.xcodeproj/xcshareddata/xcschemes/MUXSDKStatsExampleSPM.xcscheme
@@ -79,7 +79,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "ENV_KEY"
-            value = ""
+            value = "rhhn9fph0nog346n4tqb6bqda"
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM.xcodeproj/xcshareddata/xcschemes/MUXSDKStatsExampleSPM.xcscheme
+++ b/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM.xcodeproj/xcshareddata/xcschemes/MUXSDKStatsExampleSPM.xcscheme
@@ -79,7 +79,7 @@
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "ENV_KEY"
-            value = "rhhn9fph0nog346n4tqb6bqda"
+            value = ""
             isEnabled = "YES">
          </EnvironmentVariable>
          <EnvironmentVariable

--- a/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
+++ b/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
@@ -12,6 +12,7 @@ class BasicPlaybackExampleViewController: UIViewController {
     var playbackURL: URL {
         let playbackID = ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
 
+        // TODO: Should be in an automated test case
         return URL(
 //            string: "https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8"
                         string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
@@ -44,7 +45,7 @@ class BasicPlaybackExampleViewController: UIViewController {
 
         displayPlayerViewController()
 
-        // TODO: Should be an automated test case
+        // TODO: Should be automated test cases
         print("viewDidLoad: (not) About to delay monitoring")
 //        Task {
 //            try await Task.sleep(nanoseconds: 5 * 1_000_000_000)

--- a/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
+++ b/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
@@ -13,7 +13,9 @@ class BasicPlaybackExampleViewController: UIViewController {
         let playbackID = ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
 
         return URL(
-            string: "https://stream.mux.com/\(playbackID).m3u8"
+//            string: "https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8"
+                        string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
+            //            string: "https://stream.mux.com/\(playbackID).m3u8"
         )!
     }
     let playerName = "AVPlayerViewControllerExample"

--- a/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
+++ b/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
@@ -13,8 +13,8 @@ class BasicPlaybackExampleViewController: UIViewController {
         let playbackID = ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
 
         return URL(
-//            string: "https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8"
-                        string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
+            string: "https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8"
+//                        string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
             //            string: "https://stream.mux.com/\(playbackID).m3u8"
         )!
     }
@@ -46,16 +46,16 @@ class BasicPlaybackExampleViewController: UIViewController {
 
         // TODO: Should be an automated test case
         print("viewDidLoad: (not) About to delay monitoring")
-        Task {
-            try await Task.sleep(nanoseconds: 5 * 1_000_000_000)
-            let _ = await MainActor.run {
+//        Task {
+//            try await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+//            let _ = await MainActor.run {
                 MUXSDKStats.monitorAVPlayerViewController(
                     playerViewController,
                     withPlayerName: playerName,
                     customerData: customerData!
                 )
-            }
-        }
+//            }
+//        }
     }
 
     func displayPlayerViewController() {

--- a/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
+++ b/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
@@ -13,8 +13,8 @@ class BasicPlaybackExampleViewController: UIViewController {
         let playbackID = ProcessInfo.processInfo.playbackID ?? "qxb01i6T202018GFS02vp9RIe01icTcDCjVzQpmaB00CUisJ4"
 
         return URL(
-            string: "https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8"
-//                        string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
+//            string: "https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8"
+                        string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
             //            string: "https://stream.mux.com/\(playbackID).m3u8"
         )!
     }

--- a/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
+++ b/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
@@ -14,8 +14,8 @@ class BasicPlaybackExampleViewController: UIViewController {
 
         // TODO: Should be in an automated test case
         return URL(
-//            string: "https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8"
-                        string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
+            string: "https://test-streams.mux.dev/x36xhzz/url_6/193039199_mp4_h264_aac_hq_7.m3u8"
+//                        string: "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8"
             //            string: "https://stream.mux.com/\(playbackID).m3u8"
         )!
     }
@@ -47,16 +47,16 @@ class BasicPlaybackExampleViewController: UIViewController {
 
         // TODO: Should be automated test cases
         print("viewDidLoad: (not) About to delay monitoring")
-//        Task {
-//            try await Task.sleep(nanoseconds: 5 * 1_000_000_000)
-//            let _ = await MainActor.run {
+        Task {
+            try await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+            let _ = await MainActor.run {
                 MUXSDKStats.monitorAVPlayerViewController(
                     playerViewController,
                     withPlayerName: playerName,
                     customerData: customerData!
                 )
-//            }
-//        }
+            }
+        }
     }
 
     func displayPlayerViewController() {

--- a/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
+++ b/apps/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM/BasicPlaybackExampleViewController.swift
@@ -42,11 +42,18 @@ class BasicPlaybackExampleViewController: UIViewController {
 
         displayPlayerViewController()
 
-        MUXSDKStats.monitorAVPlayerViewController(
-            playerViewController,
-            withPlayerName: playerName,
-            customerData: customerData!
-        )
+        // TODO: Should be an automated test case
+        print("viewDidLoad: (not) About to delay monitoring")
+        Task {
+            try await Task.sleep(nanoseconds: 5 * 1_000_000_000)
+            let _ = await MainActor.run {
+                MUXSDKStats.monitorAVPlayerViewController(
+                    playerViewController,
+                    withPlayerName: playerName,
+                    customerData: customerData!
+                )
+            }
+        }
     }
 
     func displayPlayerViewController() {


### PR DESCRIPTION
When we can't get a source resolution or source bitrate, we can't calculate WAB, Scaling, or other VQ-related metrics.

## Cases where Src Res/Bitrate was not picked up

* Late registration: If an `AVPlayerItem` or `AVPlayer` had been used before (as when preloading or when pooling/reusing players), we won't see the events that report things like Source URL, Source Resolution, and Advertised Bitrate
* No Bitrate Advertised: If a media item doesn't advertise a bitrate, VQ and WAB can't be calculated. But we can calculate an effective bitrate based on the data we have. Examples of these cases: HLS streams that are just a bare MP (as discussed recently), HLS streams whose MVP doesn't have any `EXT-X-BITRATE` tags (they are optional), people playing progressive mp4 files (possibly; I didn't test this)

## Future-facing concerns

* It would be really great to be able to test these cases using some kind of modern, easy test harness app that allows us to make assertions in automated tests... 🤔 
* If we were listening for KVO updates on `AVPlayerItem.tracks` (including the `.initial` flag), we might be able to do some of these calculations there instead, and there'd be fewer paths that lead to this logic. Unsure if this is a real improvement or not, since the way this is written is a little more clear: "When I monitor an AVPlayerItem, I need to check for these specific things".
  * I see that as a stylistic choice, and I'm interested in others' opinions about it, if any

## Draft Until
This PR should stay a draft until I have made some automated tests to cover this case, and removed the test code from `BasicPlaybackExampleViewController`