### PR TITLE
Fix checking xcodebuild exit code in scripts

### DIFF
--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -58,8 +58,8 @@ function build_for {
         RUN_CLANG_STATIC_ANALYZER=YES \
         CLANG_STATIC_ANALYZER_MODE=deep \
         | xcbeautify
-    set -e
     local xcodebuild_exit_code="$?"
+    set -e
 
     if [ -d "$result_bundle_path" ]; then
         XCRESULT_BUNDLE_PATHS+=("$result_bundle_path")

--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -51,8 +51,8 @@ function test_for {
         -allowProvisioningUpdates \
         -disableAutomaticPackageResolution \
         | xcbeautify
-    set -e
     local xcodebuild_build_exit_code="$?"
+    set -e
 
     if [ "$xcodebuild_build_exit_code" -ne 0 ]; then
         echo "^^^ +++"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -67,8 +67,8 @@ function test_for {
         -allowProvisioningUpdates \
         -disableAutomaticPackageResolution \
         | xcbeautify
-    set -e
     local xcodebuild_build_exit_code="$?"
+    set -e
 
     if [ "$xcodebuild_build_exit_code" -ne 0 ]; then
         echo "^^^ +++"

--- a/scripts/unit-test-package.sh
+++ b/scripts/unit-test-package.sh
@@ -51,8 +51,8 @@ function test_for {
         -derivedDataPath "$DERIVED_DATA_PATH" \
         -disableAutomaticPackageResolution \
         | xcbeautify
-    set -e
     local xcodebuild_build_exit_code="$?"
+    set -e
 
     if [ "$xcodebuild_build_exit_code" -ne 0 ]; then
         echo "^^^ +++"


### PR DESCRIPTION
In _some_ of our scripts, checking the `xcodebuild` status happens after re-enabling exit on error (via `set -e`), and so it's actually checking the result of `set -e`. As a result, some things could fail silently in CI.

I noticed this when some in-progress code suspiciously passed CI checks.