### PR TITLE
Minor fix on integration tests to break while loop.

### DIFF
--- a/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
@@ -46,7 +46,10 @@ struct IntegrationTests {
             waitedTime += 0.1
             currentTimePlayer = player.currentTime().seconds
             
-            #expect(waitedTime < seconds * 2, "Expected to wait \(seconds) but player stalled for \(waitedTime) seconds, at \(currentTimePlayer - beforeTimePlayer )")
+            guard waitedTime < seconds * 2 else {
+                Issue.record("Expected to wait \(seconds) but player stalled for \(waitedTime) seconds, at \(currentTimePlayer - beforeTimePlayer )")
+                return
+              }
         }
         
         let waitTimeAfter = getLastTimestamp(for: playerName)!.doubleValue


### PR DESCRIPTION
Switched from expectation to [Issue.record + return] since expect wasn't stopping execution  