### PR TITLE
bug fix - Load Values Asynchronously For Keys causes stall

### DIFF
--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -493,7 +493,7 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
 			[asset statusOfValueForKey:@"metadata"
 								 error:&error];
 			if (status != AVKeyValueStatusLoaded || error != nil) {
-                // NSLog(@"Failed to load metadata: %@", error);
+				NSLog(@"MUXSDK-ERROR - Mux failed to load asset metadata for player name: %@", _name);
                 return;
             }
 

--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -488,12 +488,17 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
         [asset loadValuesAsynchronouslyForKeys:@[ @"metadata" ]
                              completionHandler:^{
+            __typeof(weakSelf) strongSelf = weakSelf;
+            if (strongSelf == nil) {
+                return;
+            }
+
             NSError *error = nil;
             AVKeyValueStatus status = [asset statusOfValueForKey:@"metadata"
                                                            error:&error];
             if (status != AVKeyValueStatusLoaded || error != nil) {
                 NSLog(@"MUXSDK-ERROR - Mux failed to load asset metadata for player name: %@",
-                      _name);
+                      [strongSelf name]);
                 return;
             }
             

--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -488,7 +488,7 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
         [asset loadValuesAsynchronouslyForKeys:@[ @"metadata" ]
                              completionHandler:^{
-            __typeof(weakSelf) strongSelf = weakSelf;
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
             if (strongSelf == nil) {
                 return;
             }
@@ -518,7 +518,7 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
             
             if ([sessionData count] > 0) {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    __typeof(weakSelf) strongSelf = weakSelf;
+                    __strong __typeof(weakSelf) strongSelf = weakSelf;
                     if (strongSelf == nil) {
                         return;
                     }

--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -486,25 +486,27 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     __weak MUXSDKPlayerBinding *weakSelf = self;
     
     dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-        [asset loadValuesAsynchronouslyForKeys:@[@"metadata"]
-							 completionHandler:^{
-			NSError *error = nil;
-			AVKeyValueStatus status =
-			[asset statusOfValueForKey:@"metadata"
-								 error:&error];
-			if (status != AVKeyValueStatusLoaded || error != nil) {
-				NSLog(@"MUXSDK-ERROR - Mux failed to load asset metadata for player name: %@", _name);
+        [asset loadValuesAsynchronouslyForKeys:@[ @"metadata" ]
+                             completionHandler:^{
+            NSError *error = nil;
+            AVKeyValueStatus status = [asset statusOfValueForKey:@"metadata"
+                                                           error:&error];
+            if (status != AVKeyValueStatusLoaded || error != nil) {
+                NSLog(@"MUXSDK-ERROR - Mux failed to load asset metadata for player name: %@",
+                      _name);
                 return;
             }
-
-			NSMutableDictionary *sessionData = [[NSMutableDictionary alloc] init];
+            
+            NSMutableDictionary *sessionData = [[NSMutableDictionary alloc] init];
             for (AVMetadataItem *item in asset.metadata) {
                 id<NSObject, NSCopying> key = [item key];
                 if ([key isKindOfClass:[NSString class]]) {
                     NSString *keyString = (NSString *)key;
                     if ([keyString hasPrefix:MUXSessionDataPrefix]) {
-                        NSString *itemKey = [keyString substringFromIndex:[MUXSessionDataPrefix length]];
-                        [sessionData setObject:[item value] forKey:itemKey];
+                        NSString *itemKey = [keyString
+                                             substringFromIndex: [MUXSessionDataPrefix length]];
+                        [sessionData setObject:[item value]
+                                        forKey:itemKey];
                     }
                 }
             }
@@ -517,7 +519,7 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
                     }
                     
                     MUXSDKSessionDataEvent *dataEvent = [MUXSDKSessionDataEvent new];
-                    [dataEvent setSessionData: sessionData];
+                    [dataEvent setSessionData:sessionData];
                     [MUXSDKCore dispatchEvent:dataEvent
                                     forPlayer:[strongSelf name]];
                 });

--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -484,35 +484,46 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     AVAsset *asset = _player.currentItem.asset;
     // Load Session Data from HLS manifest
     __weak MUXSDKPlayerBinding *weakSelf = self;
+    
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        [asset loadValuesAsynchronouslyForKeys:@[@"metadata"]
+							 completionHandler:^{
+			NSError *error = nil;
+			AVKeyValueStatus status =
+			[asset statusOfValueForKey:@"metadata"
+								 error:&error];
+			if (status != AVKeyValueStatusLoaded || error != nil) {
+                // NSLog(@"Failed to load metadata: %@", error);
+                return;
+            }
 
-    [asset loadValuesAsynchronouslyForKeys:@[@"metadata"]
-                         completionHandler:^{
-
-        __typeof(weakSelf) strongSelf = weakSelf;
-        if (strongSelf == nil) {
-            return;
-        }
-
-        NSMutableDictionary *sessionData = [[NSMutableDictionary alloc] init];
-
-        for (AVMetadataItem *item in asset.metadata) {
-            id<NSObject, NSCopying> key = [item key];
-            if ([key isKindOfClass:[NSString class]]) {
-                NSString *keyString = (NSString *)key;
-                if ([keyString hasPrefix:MUXSessionDataPrefix]) {
-                    NSString *itemKey = [keyString substringFromIndex:[MUXSessionDataPrefix length]];
-                    [sessionData setObject:[item value] forKey:itemKey];
+			NSMutableDictionary *sessionData = [[NSMutableDictionary alloc] init];
+            for (AVMetadataItem *item in asset.metadata) {
+                id<NSObject, NSCopying> key = [item key];
+                if ([key isKindOfClass:[NSString class]]) {
+                    NSString *keyString = (NSString *)key;
+                    if ([keyString hasPrefix:MUXSessionDataPrefix]) {
+                        NSString *itemKey = [keyString substringFromIndex:[MUXSessionDataPrefix length]];
+                        [sessionData setObject:[item value] forKey:itemKey];
+                    }
                 }
             }
-        }
-        
-        if ([sessionData count] > 0) {
-            MUXSDKSessionDataEvent *dataEvent = [MUXSDKSessionDataEvent new];
-            [dataEvent setSessionData: sessionData];
-            [MUXSDKCore dispatchEvent:dataEvent 
-                            forPlayer:[strongSelf name]];
-        }
-    }];
+            
+            if ([sessionData count] > 0) {
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    __typeof(weakSelf) strongSelf = weakSelf;
+                    if (strongSelf == nil) {
+                        return;
+                    }
+                    
+                    MUXSDKSessionDataEvent *dataEvent = [MUXSDKSessionDataEvent new];
+                    [dataEvent setSessionData: sessionData];
+                    [MUXSDKCore dispatchEvent:dataEvent
+                                    forPlayer:[strongSelf name]];
+                });
+            }
+        }];
+    });
 }
 
 - (void)stopMonitoringAVPlayerItem {


### PR DESCRIPTION
This PR tries to fix a customer reported issue causing main thread to stall (for more than 2 seconds).
 
[From the Apple docs](https://developer.apple.com/documentation/avfoundation/avasynchronouskeyvalueloading/loadvaluesasynchronously(forkeys:completionhandler:)?language=objc)
> Regardless of the number of keys specified, the system calls the completion handler only once per invocation of this method. The system calls this method:
> 
> Synchronously if the asset already loaded the specified keys, or if an I/O error or other format-related error occurs immediately.
> 
> Asynchronously when the values of the specified keys become loaded, if a loading error occurs at a later stage of processing, or you cancel loading. The system calls the closure on a background queue, so you should dispatch control back to the main queue before performing any user interface-related operations.

I couldn't reproduce this issue yet, but I added error checking on the completion handler and moved the execution off the main thread.

Added note: this function appears as deprecated on Apple Docs, however this is for Swift only
![Screenshot 2025-06-05 at 6 04 54 PM](https://github.com/user-attachments/assets/2177126c-8bdc-4aec-a216-f7b27b1dd318)

![Screenshot 2025-06-05 at 6 06 12 PM](https://github.com/user-attachments/assets/38a7fdb0-9352-4f38-b4d3-8689d68c48a1)

![Screenshot 2025-06-05 at 6 06 07 PM](https://github.com/user-attachments/assets/42b4229d-b6e6-4250-b3ae-955c80dcbe3d)


