### PR TITLE
Strict Swift Concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:6.0
 
 import PackageDescription
 
@@ -8,6 +8,7 @@ let package = Package(
         .iOS(.v12),
         .macCatalyst(.v13),
         .tvOS(.v12),
+        .visionOS(.v1),
     ],
     products: [
         .library(name: "MUXSDKStats", targets: ["MUXSDKStats"]),
@@ -42,4 +43,13 @@ let package = Package(
             dependencies: [
                 "MUXSDKStatsInternal",
             ]),
+    ],
+    swiftLanguageModes: [
+        .v5,
     ])
+
+for target in package.targets {
+    target.swiftSettings = (target.swiftSettings ?? []) + [
+        .enableExperimentalFeature("StrictConcurrency")
+    ]
+}

--- a/Sources/MUXSDKStatsInternal/AVPlayerItem+AccessLog.swift
+++ b/Sources/MUXSDKStatsInternal/AVPlayerItem+AccessLog.swift
@@ -29,8 +29,7 @@ extension AVPlayerItem {
                         _ = await NotificationCenter.default
                             .notifications(named: AVPlayerItem.newAccessLogEntryNotification,
                                            object: self)
-                            .makeAsyncIterator()
-                            .next()
+                            .first(where: { _ in true })
                     }
 
                     defer {
@@ -39,6 +38,8 @@ extension AVPlayerItem {
 
                     return try await group.nextResult()!.get()
                 }
+
+                try Task.checkCancellation()
             }
         }
     }

--- a/Sources/MUXSDKStatsInternal/Future+async.swift
+++ b/Sources/MUXSDKStatsInternal/Future+async.swift
@@ -2,9 +2,10 @@ import Combine
 
 @available(iOS 13, tvOS 13, *)
 extension Future where Failure == Never {
-    convenience init(priority: TaskPriority? = nil, operation: sending @escaping @isolated(any) () async -> Output) {
+    convenience init(isolation: isolated (any Actor)? = #isolation, operation: @escaping () async -> sending Output) {
         self.init { promise in
-            Task(priority: priority) {
+            Task {
+                _ = isolation
                 promise(.success(await operation()))
             }
         }

--- a/Sources/MUXSDKStatsInternal/MUXSDKVideoData.swift
+++ b/Sources/MUXSDKStatsInternal/MUXSDKVideoData.swift
@@ -36,13 +36,20 @@ extension MUXSDKVideoData {
     }
 
     @available(iOS 15, tvOS 15, *)
-    func updateWithRenditionInfo(track: AVAssetTrack, on playerItem: AVPlayerItem) async {
+    static func renditionInfo(track: AVAssetTrack, on playerItem: AVPlayerItem) async -> sending Self {
+        let videoData = Self()
         // Obtain recent bitrate stats immediately in case another variant switch happens
-        async let bitratesFromAccessLog = withTimeout(of: 5.0) {
-            try await playerItem.indicatedBitratesInAccessLog
+        async let bitratesFromAccessLog = withTimeout(seconds: 5) {
+            Array(try await playerItem.indicatedBitratesInAccessLog.suffix(3))
         }
         // Start loading this early:
-        async let assetVariantsOrNil = (playerItem.asset as? AVURLAsset)?.load(.variants)
+        async let assetVariantsOrNil = {
+            // AVURLAsset subclass is Sendable
+            let urlAsset = await MainActor.run {
+                playerItem.asset as? AVURLAsset
+            }
+            return try await urlAsset?.load(.variants)
+        }()
 
         let nominalFrameRate: Float?
         let presentationSize: CGSize?
@@ -70,7 +77,7 @@ extension MUXSDKVideoData {
             if !(error is CancellationError) {
                 logger.error("Track \(track.trackID): failed to load basic video attributes: \(error)")
             }
-            return
+            return videoData
         }
 
         let videoCodecs = Set<CMVideoCodecType>(
@@ -81,13 +88,13 @@ extension MUXSDKVideoData {
 
         // Set these right away so they're available even if variants are unavailable or matching fails:
         if let nominalFrameRate {
-            videoSourceAdvertisedFrameRate = nominalFrameRate as NSNumber
+            videoData.videoSourceAdvertisedFrameRate = nominalFrameRate as NSNumber
         }
         if let presentationSize {
-            updateWithPresentationSize(presentationSize)
+            videoData.updateWithPresentationSize(presentationSize)
         }
         if !videoCodecs.isEmpty {
-            updateWithVideoCodecTypes(Array(videoCodecs))
+            videoData.updateWithVideoCodecTypes(Array(videoCodecs))
         }
 
         // Matching below based on the following assumptions:
@@ -105,14 +112,14 @@ extension MUXSDKVideoData {
         do {
             // Bail out when no variants present (including non-HLS assets)
             guard let assetVariantsOrNil = try await assetVariantsOrNil, !assetVariantsOrNil.isEmpty else {
-                return
+                return videoData
             }
             assetVariants = assetVariantsOrNil
         } catch {
             if !(error is CancellationError) {
                 logger.error("Track \(track.trackID): failed to load variants: \(error)")
             }
-            return
+            return videoData
         }
 
         let matchingVariants = assetVariants.filter { variant in
@@ -151,10 +158,10 @@ extension MUXSDKVideoData {
                     videoRangeIsHDR=\(videoRangeIsHDR.debugDescription)
                     variants=\(assetVariants)
                 """)
-            return
+            return videoData
         case 1:
-            updateWithAssetVariant(matchingVariants.first!)
-            return
+            videoData.updateWithAssetVariant(matchingVariants.first!)
+            return videoData
         default:
             break
         }
@@ -165,19 +172,19 @@ extension MUXSDKVideoData {
         let recentBitrates: [Double]
 
         do {
-            recentBitrates = try await bitratesFromAccessLog.suffix(3)
+            recentBitrates = try await bitratesFromAccessLog
         } catch {
             if !(error is CancellationError) {
                 logger.debug("Track \(track.trackID): failed to load bitrates from access log: \(error)")
             }
-            return
+            return videoData
         }
 
         // Effectively handles getting the initial bitrate for a stream, which is an increasingly common use case.
         // There will be one matching entry in the access log, and all further variant info will come from
         // `AVMetricPlayerItemVariantSwitchEvent.toVariant` on iOS 18+.
         if recentBitrates.count == 1 {
-            videoSourceAdvertisedBitrate = recentBitrates.first! as NSNumber
+            videoData.videoSourceAdvertisedBitrate = recentBitrates.first! as NSNumber
         }
 
         for bitrate in recentBitrates.reversed() {
@@ -188,12 +195,12 @@ extension MUXSDKVideoData {
             case 0:
                 break
             case 1:
-                updateWithAssetVariant(bitrateMatched.first!)
-                return
+                videoData.updateWithAssetVariant(bitrateMatched.first!)
+                return videoData
             default:
-                videoSourceAdvertisedBitrate = recentBitrates.first! as NSNumber
+                videoData.videoSourceAdvertisedBitrate = recentBitrates.first! as NSNumber
                 logger.debug("Track \(track.trackID): Multiple matching variants detected after filtering by bitrate=\(bitrate): \(bitrateMatched)")
-                return
+                return videoData
             }
         }
 
@@ -206,6 +213,7 @@ extension MUXSDKVideoData {
                 recentBitrates=\(recentBitrates)
                 variants=\(assetVariants)
             """)
+        return videoData
     }
 }
 

--- a/Sources/MUXSDKStatsInternal/MUXSDKVideoData.swift
+++ b/Sources/MUXSDKStatsInternal/MUXSDKVideoData.swift
@@ -36,7 +36,7 @@ extension MUXSDKVideoData {
     }
 
     @available(iOS 15, tvOS 15, *)
-    static func renditionInfo(track: AVAssetTrack, on playerItem: AVPlayerItem) async -> sending Self {
+    static func makeWithRenditionInfo(track: AVAssetTrack, on playerItem: AVPlayerItem) async -> sending Self {
         let videoData = Self()
         // Obtain recent bitrate stats immediately in case another variant switch happens
         async let bitratesFromAccessLog = withTimeout(seconds: 5) {

--- a/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
+++ b/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
@@ -40,12 +40,14 @@ extension PlayerMonitor {
             .store(in: &cancellables)
     }
 
-    @objc public convenience init(player: AVPlayer, onEvent: (@escaping @MainActor (MUXSDKBaseEvent) -> Void)) {
+    @objc public convenience init(player: AVPlayer, onEvent: @Sendable @escaping @MainActor (MUXSDKBaseEvent) -> Void) {
         self.init(player: player)
 
         allEvents
             .receive(on: ImmediateIfOnMainQueueScheduler.shared)
             .sink(receiveValue: { event in
+                // work around Sendable requirement on assumeIsolated
+                nonisolated(unsafe) let event = event
                 MainActor.assumeIsolated {
                     onEvent(event)
                 }

--- a/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
@@ -45,12 +45,15 @@ extension AVPlayerItem {
         validTracksPublisher
             // @MainActor isolated: AVPlayerItemTrack (and therefore its assetTrack property)
             .receive(on: ImmediateIfOnMainQueueScheduler.shared)
-            .map { tracks in
+            .map { (tracks: [AVPlayerItemTrack]) -> AVAssetTrack? in
+                // work around Sendable requirement on assumeIsolated
+                nonisolated(unsafe) var videoAssetTrack: AVAssetTrack? = nil
                 MainActor.assumeIsolated {
-                    tracks.lazy
+                    videoAssetTrack = tracks.lazy
                         .compactMap(\.assetTrack)
                         .first { $0.mediaType == .video }
                 }
+                return videoAssetTrack
             }
             .removeDuplicates { $0?.trackID == $1?.trackID }
             .flatMap { videoAssetTrack in
@@ -58,11 +61,10 @@ extension AVPlayerItem {
                 let timing = PlaybackEventTiming(playerItem: self)
 
                 return Future {
-                    let videoData = MUXSDKVideoData()
-                    if let videoAssetTrack {
-                        await videoData.updateWithRenditionInfo(track: videoAssetTrack, on: self)
+                    guard let videoAssetTrack else {
+                        return (timing, MUXSDKVideoData())
                     }
-                    return (timing, videoData)
+                    return (timing, await MUXSDKVideoData.renditionInfo(track: videoAssetTrack, on: self))
                 }
             }
     }

--- a/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
@@ -126,6 +126,7 @@ extension AVPlayerItem {
     nonisolated func renditionChangeEventsUsingAVMetrics() -> some Publisher<MUXSDKRenditionChangeEvent, Error> {
         metrics(forType: AVMetricPlayerItemVariantSwitchEvent.self)
             .filter(\.didSucceed)
+            .publisher
             .map { metricEvent in
                 let timing = PlaybackEventTiming(variantSwitchEvent: metricEvent, on: self)
 
@@ -141,7 +142,6 @@ extension AVPlayerItem {
 
                 return muxEvent
             }
-            .publisher
     }
 }
 

--- a/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
@@ -122,7 +122,6 @@ extension AVPlayerItem {
             suffix: changeEvents.map { $0 as MUXSDKBaseEvent })
     }
 
-#if !targetEnvironment(simulator)
     @available(iOS 18, tvOS 18, visionOS 2, *)
     nonisolated func renditionChangeEventsUsingAVMetrics() -> some Publisher<MUXSDKRenditionChangeEvent, Error> {
         metrics(forType: AVMetricPlayerItemVariantSwitchEvent.self)
@@ -144,7 +143,6 @@ extension AVPlayerItem {
             }
             .publisher
     }
-#endif
 }
 
 @available(iOS 15, tvOS 15, *)

--- a/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
@@ -64,7 +64,7 @@ extension AVPlayerItem {
                     guard let videoAssetTrack else {
                         return (timing, MUXSDKVideoData())
                     }
-                    return (timing, await MUXSDKVideoData.renditionInfo(track: videoAssetTrack, on: self))
+                    return (timing, await MUXSDKVideoData.makeWithRenditionInfo(track: videoAssetTrack, on: self))
                 }
             }
     }

--- a/Sources/MUXSDKStatsInternal/Publishers+AsyncSequence.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AsyncSequence.swift
@@ -3,9 +3,16 @@ import Combine
 @available(iOS 18, tvOS 18, visionOS 2, *)
 extension AsyncSequence {
     var publisher: some Publisher<Element, Failure> {
+        Deferred {
+            publishedImmediately()
+        }
+    }
+
+    func publishedImmediately(isolation: isolated (any Actor)? = #isolation) -> some Publisher<Element, Failure> {
         let subject = PassthroughSubject<Element, Failure>()
 
         let task = Task<Void, Never> {
+            _ = isolation
             do throws(Failure) {
                 for try await element in self {
                     if Task.isCancelled {

--- a/Sources/MUXSDKStatsInternal/Publishers+AsyncSequence.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AsyncSequence.swift
@@ -1,7 +1,7 @@
 import Combine
 
 @available(iOS 18, tvOS 18, visionOS 2, *)
-extension AsyncSequence {
+extension AsyncSequence where Self: Sendable {
     var publisher: some Publisher<Element, Failure> {
         Deferred {
             publishedImmediately()

--- a/Sources/MUXSDKStatsInternal/Task+Timeout.swift
+++ b/Sources/MUXSDKStatsInternal/Task+Timeout.swift
@@ -4,18 +4,27 @@ struct TimeoutError: Error {
 }
 
 @available(iOS 13, tvOS 13, *)
-func withTimeout<Output>(of seconds: TimeInterval, operation: sending @escaping @isolated(any) () async throws -> Output) async throws -> Output {
-    try await withThrowingTaskGroup(of: Output.self) { group in
-        group.addTask(operation: operation)
-        group.addTask {
-            try await Task.sleep(nanoseconds: UInt64(seconds * Double(NSEC_PER_SEC)))
-            throw TimeoutError()
+func withTimeout<T: Sendable>(seconds: TimeInterval, operation: sending @escaping @isolated(any) () async throws -> T) async throws -> T {
+    let workTask = Task {
+        try await operation()
+    }
+    return try await withCheckedThrowingContinuation { continuation in
+        Task {
+            await withThrowingTaskGroup(of: T.self) { group in
+                defer {
+                    workTask.cancel()
+                    group.cancelAll()
+                }
+                group.addTask {
+                    try await workTask.value
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(seconds * Double(NSEC_PER_SEC)))
+                    throw TimeoutError()
+                }
+                let firstResult = await group.nextResult()!
+                continuation.resume(with: firstResult)
+            }
         }
-
-        defer {
-            group.cancelAll()
-        }
-
-        return try await group.nextResult()!.get()
     }
 }

--- a/Tests/MUXSDKStatsInternalTests/Task+TimeoutTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/Task+TimeoutTests.swift
@@ -5,29 +5,70 @@ import Testing
 
 struct TaskTimeoutTests {
     @Test func testTimeoutDoesNotFireImmediate() async throws {
-        try await withTimeout(of: 0.1) {
+        try await withTimeout(seconds: 0.1) {
             #expect(!Task.isCancelled, "operation should not be cancelled ")
         }
     }
 
+    @Test func testTimeoutDoesNotFireYield() async throws {
+        try await withTimeout(seconds: 0.1) {
+            await Task.yield()
+            #expect(!Task.isCancelled, "operation should not be cancelled ")
+        }
+    }
 
-    @Test func testTimeoutFiresNonBlocking() async throws {
-        await #expect(throws: TimeoutError.self) {
-            try await withTimeout(of: 0.1) {
-                await withCheckedContinuation { continuation in
-                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
-                        continuation.resume()
+    @Test func testReturnsEarlyOnTimeoutNonBlocking() async throws {
+        await withCheckedContinuation { endOfOperationContinuation in
+            Task {
+                var continuationThatTimesOut: CheckedContinuation<Void, Never>? = nil
+
+                // waits forever if withTimeout doesn't return before its timed-out operation does
+                _ = await #expect(throws: TimeoutError.self) {
+                    try await withTimeout(seconds: 0.1) {
+                        await withCheckedContinuation { continuationThatTimesOut = $0 }
+                        #expect(Task.isCancelled, "timed-out operation should be cancelled ")
+                        endOfOperationContinuation.resume()
                     }
                 }
-                #expect(Task.isCancelled, "timed-out operation should be cancelled ")
+
+                continuationThatTimesOut?.resume()
             }
         }
     }
 
+    @Test func testReturnsEarlyOnTimeoutBlocking() async throws {
+        await withCheckedContinuation { endOfOperationContinuation in
+            Task {
+                let sempahore = DispatchSemaphore(value: 0)
+
+                // waits forever if withTimeout doesn't return before its timed-out operation does
+                _ = await #expect(throws: TimeoutError.self) {
+                    try await withTimeout(seconds: 0.1) {
+                        await withCheckedContinuation { continuation in
+                            sempahore.wait()
+                            continuation.resume()
+                        }
+                        #expect(Task.isCancelled, "timed-out operation should be cancelled ")
+                        endOfOperationContinuation.resume()
+                    }
+                }
+
+                sempahore.signal()
+            }
+        }
+    }
+
+    @Test func testTimeoutDoesNotFireCooperative() async throws {
+        try await withTimeout(seconds: 0.1) {
+            try await Task.sleep(nanoseconds: UInt64(NSEC_PER_MSEC * 25))
+            #expect(!Task.isCancelled, "operation should not be cancelled ")
+        }
+    }
+
     @Test func testTimeoutDoesNotFireNonBlocking() async throws {
-        try await withTimeout(of: 0.1) {
+        try await withTimeout(seconds: 0.1) {
             await withCheckedContinuation { continuation in
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(25)) {
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(25)) {
                     continuation.resume()
                 }
             }
@@ -35,19 +76,10 @@ struct TaskTimeoutTests {
         }
     }
 
-    @Test func testTimeoutFiresBlocking() async throws {
-        await #expect(throws: TimeoutError.self) {
-            try await withTimeout(of: 0.1) {
-                #expect(0 == usleep(500000))
-            }
-            #expect(Task.isCancelled, "timed-out operation should be cancelled ")
-        }
-    }
-
     @Test func testTimeoutDoesNotFireBlocking() async throws {
-        try await withTimeout(of: 0.1) {
+        try await withTimeout(seconds: 0.1) {
             #expect(0 == usleep(25000))
+            #expect(!Task.isCancelled, "operation should not be cancelled ")
         }
-        #expect(!Task.isCancelled, "operation should not be cancelled ")
     }
 }

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -55,6 +55,8 @@ function build_for {
         -resultBundlePath "$result_bundle_path" \
         -disableAutomaticPackageResolution \
         -derivedDataPath "$DERIVED_DATA_PATH" \
+        GCC_TREAT_WARNINGS_AS_ERRORS=YES \
+        SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
         RUN_CLANG_STATIC_ANALYZER=YES \
         CLANG_STATIC_ANALYZER_MODE=deep \
         | xcbeautify


### PR DESCRIPTION
Updates package to reflect Xcode 16 requirements (swift-tools-version:6.0), enables strict concurrency checking, and makes related updates to comply with this strict compiler mode.

No unsafe or escape hatch solutions were used except for getting around the unnecessarily strict sendability requirement on `MainActor.assumeIsolated`, and comments were added to explain.

Tested locally as well with Xcode 16.0, which is the oldest version that can make App Store submissions.