### PR TITLE
More explicit Swift monitor enable/disable

### DIFF
--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -668,22 +668,26 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
             videoDataUpdated = YES;
         }
     }
-    if (![self doubleValueIsEqual:@(_lastDispatchedAdvertisedBitrate) toOther:@(_lastAdvertisedBitrate)]) {
-        videoDataUpdated = YES;
-        _lastDispatchedAdvertisedBitrate = _lastAdvertisedBitrate;
-        _sourceDimensionsHaveChanged = YES;
-    }
-    if (_sourceDimensionsHaveChanged && CGSizeEqualToSize(_videoSize, _lastDispatchedVideoSize)) {
-        CGSize sourceDimensions = [self getSourceDimensions];
-        if (!CGSizeEqualToSize(_videoSize, sourceDimensions)) {
-            _videoSize = sourceDimensions;
-            if (sourceDimensions.width > 0 && sourceDimensions.height > 0) {
-                _lastDispatchedVideoSize = _videoSize;
-                _sourceDimensionsHaveChanged = NO;
-                videoDataUpdated = YES;
+
+    if (self.shouldTrackRenditionChanges) {
+        if (![self doubleValueIsEqual:@(_lastDispatchedAdvertisedBitrate) toOther:@(_lastAdvertisedBitrate)]) {
+            videoDataUpdated = YES;
+            _lastDispatchedAdvertisedBitrate = _lastAdvertisedBitrate;
+            _sourceDimensionsHaveChanged = YES;
+        }
+        if (_sourceDimensionsHaveChanged && CGSizeEqualToSize(_videoSize, _lastDispatchedVideoSize)) {
+            CGSize sourceDimensions = [self getSourceDimensions];
+            if (!CGSizeEqualToSize(_videoSize, sourceDimensions)) {
+                _videoSize = sourceDimensions;
+                if (sourceDimensions.width > 0 && sourceDimensions.height > 0) {
+                    _lastDispatchedVideoSize = _videoSize;
+                    _sourceDimensionsHaveChanged = NO;
+                    videoDataUpdated = YES;
+                }
             }
         }
     }
+
     NSNumber *checkedFrameDrops = nil;
     if(_totalFrameDropsHasChanged && _totalFrameDrops > 0) {
         _totalFrameDropsHasChanged = NO;
@@ -693,9 +697,14 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
     
     if (videoDataUpdated) {
         MUXSDKVideoData *videoData = [[MUXSDKVideoData alloc] init];
-        if (_videoSize.width > 0 && _videoSize.height > 0) {
-            [videoData setVideoSourceWidth:[NSNumber numberWithInt:_videoSize.width]];
-            [videoData setVideoSourceHeight:[NSNumber numberWithInt:_videoSize.height]];
+        if (self.shouldTrackRenditionChanges) {
+            if (_videoSize.width > 0 && _videoSize.height > 0) {
+                [videoData setVideoSourceWidth:[NSNumber numberWithInt:_videoSize.width]];
+                [videoData setVideoSourceHeight:[NSNumber numberWithInt:_videoSize.height]];
+            }
+            if (_lastAdvertisedBitrate > 0 && _started) {
+                [videoData setVideoSourceAdvertisedBitrate:@(_lastAdvertisedBitrate)];
+            }
         }
         if (_videoIsLive) {
             [videoData setVideoSourceIsLive:@"true"];
@@ -710,9 +719,6 @@ NSString * RemoveObserverExceptionName = @"NSRangeException";
         }
         if (_videoURL) {
             [videoData setVideoSourceUrl:_videoURL];
-        }
-        if (_lastAdvertisedBitrate > 0 && _started) {
-            [videoData setVideoSourceAdvertisedBitrate:@(_lastAdvertisedBitrate)];
         }
         if(checkedFrameDrops) {
             [videoData setVideoSourceFrameDrops:checkedFrameDrops];

--- a/Tests/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/Tests/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -724,7 +724,11 @@ static NSString *Z = @"Z";
                                                                                      viewData:nil];
 
     NSString *playName = @"Player";
-    [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
+    MUXSDKPlayerBinding *binding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
+    if (![[binding valueForKey:@"shouldTrackRenditionChanges"] boolValue]) {
+        // Mocking via notification is only available when tracking via binding
+        return;
+    }
     [controller.player play];
     
     NSDictionary *renditionInfo = @{
@@ -774,7 +778,11 @@ static NSString *Z = @"Z";
                                                                                      viewData:nil];
 
     NSString *playName = @"Player";
-    [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
+    MUXSDKPlayerBinding *binding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
+    if (![[binding valueForKey:@"shouldTrackRenditionChanges"] boolValue]) {
+        // Mocking via notification is only available when tracking via binding
+        return;
+    }
     [controller.player play];
     
     NSDictionary *renditionInfo = @{
@@ -816,7 +824,11 @@ static NSString *Z = @"Z";
                                                                                      viewData:nil];
 
     NSString *playName = @"Player";
-    [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
+    MUXSDKPlayerBinding *binding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
+    if (![[binding valueForKey:@"shouldTrackRenditionChanges"] boolValue]) {
+        // Mocking via notification is only available when tracking via binding
+        return;
+    }
     [controller.player play];
 
     [MUXSDKStats orientationChangeForPlayer:playName withOrientation:MUXSDKViewOrientationPortrait];

--- a/Tests/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/Tests/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -14,6 +14,8 @@
 #import "Utils/MUXSDKCore+Mock.h"
 #import "MUXSDKPlayerBindingConstants.h"
 
+#define MUXUniquePlayerName() [NSString stringWithFormat:@"Player for %s (%@)", __PRETTY_FUNCTION__, NSUUID.UUID.UUIDString]
+
 @interface MuxMockAVPlayerViewController : AVPlayerViewController
 @end
 
@@ -154,7 +156,7 @@ static NSString *Z = @"Z";
                                                                                      viewData:nil
                                                                                    customData:customData];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerViewController to return a playerBinding");
     [customData setCustomData1:@"bar"];
@@ -180,7 +182,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:customerViewData];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerViewController to return a playerBinding");
     [customerViewData setViewSessionId:@"bar"];
@@ -204,7 +206,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerViewController to return a playerBinding");
     [customerVideoData setVideoTitle:@"56789"];
@@ -231,7 +233,7 @@ static NSString *Z = @"Z";
     NSURL* firstVideoURL = [NSURL URLWithString:@"http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8"];
     AVPlayerItem *firstItem = [AVPlayerItem playerItemWithURL:firstVideoURL];
     [controller.player replaceCurrentItemWithPlayerItem:firstItem];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerViewController to return a playerBinding");
     
@@ -306,7 +308,7 @@ static NSString *Z = @"Z";
                                                                                    customData:nil
                                                                                    viewerData:customerViewerData];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerLayer to return a playerBinding");
     [customerViewData setViewSessionId:@"bar"];
@@ -344,7 +346,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerLayer to return a playerBinding");
     [customerVideoData setVideoTitle:@"56789"];
@@ -373,7 +375,7 @@ static NSString *Z = @"Z";
     NSURL* firstVideoURL = [NSURL URLWithString:@"http://qthttp.apple.com.edgesuite.net/1010qwoeiuryfg/sl.m3u8"];
     AVPlayerItem *firstItem = [AVPlayerItem playerItemWithURL:firstVideoURL];
     [controller.player replaceCurrentItemWithPlayerItem:firstItem];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerLayer to return a playerBinding");
     
@@ -441,7 +443,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *playerBinding = [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     XCTAssertNotNil(playerBinding, "expected monitorAVPlayerViewController to return a playerBinding");
     [customerVideoData setVideoTitle:@"56789"];
@@ -471,7 +473,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil
                                                                                    customData:customData];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:nil videoData:nil viewData:nil];
     [MUXSDKStats setCustomerData:customerData forPlayer:playName];
@@ -518,7 +520,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil
                                                                                    customData:customData];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:nil videoData:nil viewData:nil];
     [MUXSDKStats setCustomerData:customerData forPlayer:playName];
@@ -544,7 +546,7 @@ static NSString *Z = @"Z";
     MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:customerPlayerData
                                                                                     videoData:customerVideoData
                                                                                      viewData:customerViewData];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:nil videoData:nil viewData:nil];
     [MUXSDKStats setCustomerData:customerData forPlayer:playName];
@@ -571,7 +573,7 @@ static NSString *Z = @"Z";
     MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:customerPlayerData
                                                                                     videoData:customerVideoData
                                                                                      viewData:customerViewData];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     [customerPlayerData setPlayerVersion:@"playerVersionV1"];
     [customerViewData setViewSessionId:@"baz"];
@@ -598,7 +600,7 @@ static NSString *Z = @"Z";
     MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:customerPlayerData
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     [customerPlayerData setPlayerVersion:@"playerVersionV1"];
     customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:customerPlayerData videoData:nil viewData:nil];
@@ -623,7 +625,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     [customerVideoData setVideoTitle:@"Updated VideoTitle"];
     customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:nil
@@ -648,7 +650,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
     [customerVideoData setVideoTitle:@"01234"];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerViewController:controller withPlayerName:playName customerData:customerData];
     [MUXSDKStats destroyPlayer:playName];
     NSArray *expectedEventTypes = @[MUXSDKPlaybackEventViewInitEventType,
@@ -671,7 +673,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     
     [MUXSDKStats orientationChangeForPlayer:playName withOrientation:MUXSDKViewOrientationPortrait];
@@ -711,7 +713,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     MUXSDKPlayerBinding *binding = [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
     if (![[binding valueForKey:@"shouldTrackRenditionChanges"] boolValue]) {
         // Mocking via notification is only available when tracking via binding
@@ -882,7 +884,7 @@ static NSString *Z = @"Z";
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
 
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
 
     [MUXSDKStats dispatchError:@"12345" withMessage:@"Something aint right" forPlayer:playName];
@@ -906,7 +908,7 @@ static NSString *Z = @"Z";
     MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:customerPlayerData
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
 
     [MUXSDKStats dispatchError:@"12345"
@@ -940,7 +942,7 @@ static NSString *Z = @"Z";
     MUXSDKCustomerData *customerData = [[MUXSDKCustomerData alloc] initWithCustomerPlayerData:customerPlayerData
                                                                                     videoData:customerVideoData
                                                                                      viewData:nil];
-    NSString *playName = @"Player";
+    NSString *playName = MUXUniquePlayerName();
     [MUXSDKStats monitorAVPlayerLayer:controller withPlayerName:playName customerData:customerData];
 
     [MUXSDKStats dispatchError:@"12345"

--- a/Tests/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/Tests/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -61,15 +61,9 @@ static NSString *Z = @"Z";
 }
 
 - (void) assertDispatchedGlobalEventTypes:(NSArray *) expectedEventTypes {
-    NSInteger expectedCount = expectedEventTypes.count;
-    NSInteger actualCount = [MUXSDKCore globalEventsCount];
-    XCTAssertEqual(expectedCount, actualCount, @"expected: %ld events got: %ld events.", (long)expectedCount, (long)actualCount);
-    for (int i = 0; i < expectedEventTypes.count; i++) {
-        MUXSDKDataEvent *event = [MUXSDKCore globalEventAtIndex:i];
-        NSString *expectedType = [expectedEventTypes objectAtIndex:i];
-        NSString *actualType = [event getType];
-        XCTAssertEqual(expectedType, actualType, @"index [%d] expected event type: %@ got event type: %@", i, expectedType, actualType);
-    }
+    NSArray<MUXSDKDataEvent *> *globalEvents = [MUXSDKCore snapshotOfGlobalEvents];
+    NSArray<NSString *> *globalEventTypes = [globalEvents valueForKeyPath:NSStringFromSelector(@selector(getType))];
+    XCTAssertEqualObjects(globalEventTypes, expectedEventTypes);
 }
 
 - (void) assertPlayer:(NSString *)name dispatchedPlaybackEvents:(NSDictionary *) expectedViewData {
@@ -91,15 +85,9 @@ static NSString *Z = @"Z";
 }
 
 - (void) assertPlayer:(NSString *)name dispatchedEventTypes:(NSArray *) expectedEventTypes {
-    NSInteger expectedCount = expectedEventTypes.count;
-    NSInteger actualCount = [MUXSDKCore eventsCountForPlayer:name];
-    XCTAssertEqual(expectedCount, actualCount, @"expected: %ld events got: %ld events.", (long)expectedCount, (long)actualCount);
-    for (int i = 0; i < expectedEventTypes.count; i++) {
-        id<MUXSDKEventTyping> event = [MUXSDKCore eventAtIndex:i forPlayer:name];
-        NSString *expectedType = [expectedEventTypes objectAtIndex:i];
-        NSString *actualType = [event getType];
-        XCTAssertEqual(expectedType, actualType, @"index [%d] expected event type: %@ got event type: %@", i, expectedType, actualType);
-    }
+    NSArray<id<MUXSDKEventTyping>> *events = [MUXSDKCore snapshotOfEventsForPlayer:name];
+    NSArray<NSString *> *eventTypes = [events valueForKeyPath:NSStringFromSelector(@selector(getType))];
+    XCTAssertEqualObjects(eventTypes, expectedEventTypes);
 }
 
 - (void) assertPlayer:(NSString *)name dispatchedDataEvents:(NSDictionary *) expectedVideoData {


### PR DESCRIPTION
Fully disables the Objective-C implementation of rendition change tracking video source width/height when the Swift implementation is active. Notably this avoids the `-getSourceDimensions` method which is wrapped in a big `@try/@catch`. Also avoids a few code paths related to rendition bitrate tracking.