### PR TITLE
fix duplicated "unique" KVO context pointer

### DIFF
--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -37,7 +37,7 @@ static void *MUXSDKAVPlayerCurrentItemObservationContext = &MUXSDKAVPlayerCurren
 static void *MUXSDKAVPlayerTimeControlStatusObservationContext = &MUXSDKAVPlayerTimeControlStatusObservationContext;
 
 // AVPlayerItem observation contexts.
-static void *MUXSDKAVPlayerItemStatusObservationContext = &MUXSDKAVPlayerStatusObservationContext;
+static void *MUXSDKAVPlayerItemStatusObservationContext = &MUXSDKAVPlayerItemStatusObservationContext;
 static void *MUXSDKAVPlayerItemPlaybackBufferEmptyObservationContext = &MUXSDKAVPlayerItemPlaybackBufferEmptyObservationContext;
 
 // This is the name of the exception that gets thrown when we remove an observer that


### PR DESCRIPTION
When registering for and receiving Key-Value Observing change notifications, a unique context pointer can be used. A common way to get a unique pointer for each logically separate use of this API is to assign a `static void *` the address of itself. Here it seems we have a duplicate (probably copy/paste error) so effectively we're sharing a "unique" id for two separate usages.

In practice, these two usages will never overlap because:
* one is for the AVPlayer object and the other is for the AVPlayerItem object
* in the change handler we don't try to access the object or property
* in the change handler we end up calling the same method in either case
* when deregistering we don't use contexts at all (though it is recommended)

Of course if _any_ of that changed we'd be in trouble.