### PR TITLE
Changing the Source Integration Test

### DIFF
--- a/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct IntegrationTests {
     let dispatchDelay = 3.0
     let msTolerance: Double = 2000
-
+    
     func getLastTimestamp(for playerName: String) -> NSNumber? {
         return MUXSDKCore.getPlayheadTimeStamps(forPlayer: playerName).last
     }
@@ -27,7 +27,7 @@ struct IntegrationTests {
             player.play()
         }
         try? await Task.sleep(nanoseconds: UInt64(dispatchDelay * 1_000_000_000))
-
+        
         let events = getEventsAndReset(for: playerName)
         
         let containsPlayEvent = events?.contains { $0 is MUXSDKPlayEvent } ?? false
@@ -51,7 +51,7 @@ struct IntegrationTests {
             guard waitedTime < seconds * 2 else {
                 Issue.record("Expected to wait \(seconds) but player stalled for \(waitedTime) seconds, at \(currentTimePlayer - beforeTimePlayer )")
                 return
-              }
+            }
         }
         
         let waitTimeAfter = getLastTimestamp(for: playerName)!.doubleValue
@@ -118,21 +118,69 @@ struct IntegrationTests {
         #expect(containsEndEvent)
     }
     
+    func assertChangeVideoSource(from firstURL: String, to secondURL: String, with player: AVPlayer, for playerName: String) {
+        NSLog("## Change video source from \(firstURL) to \(secondURL)")
+        
+        // Create CVD for the new video, to use in the videoChange
+        let customerVideoData = MUXSDKCustomerVideoData()
+        customerVideoData.videoTitle = "Second Video Title"
+        customerVideoData.videoId = "second_video_id"
+        
+        let customerData = MUXSDKCustomerData()
+        customerData.customerVideoData = customerVideoData
+        
+        // Manually trigger video change
+        MUXSDKStats.videoChange(forPlayer: playerName, with: customerData)
+        
+        // Replace current item with new URL
+        let newURL = URL(string: secondURL)!
+        let newPlayerItem = AVPlayerItem(url: newURL)
+        player.replaceCurrentItem(with: newPlayerItem)
+        
+        Thread.sleep(forTimeInterval: dispatchDelay)
+        
+        let events = getEventsAndReset(for: playerName)
+        
+        guard let events = events else {
+            Issue.record("No events captured during video source change")
+            return
+        }
+        
+        // Find the ViewEnd event index
+        let viewEndIndex = events.firstIndex { $0 is MUXSDKViewEndEvent }
+        
+        // Expect ViewEnd event was sent
+        #expect(viewEndIndex != nil, "Expected ViewEnd event when changing video source")
+        
+        guard let viewEndIndex = viewEndIndex else {
+            return
+        }
+        
+        let eventsAfterViewEnd = Array(events[(viewEndIndex + 1)...])
+        
+        // Find one MUXSDKDataEvent after ViewEnd
+        let dataEventAfterViewEnd = eventsAfterViewEnd.first { $0 is MUXSDKDataEvent } as? MUXSDKDataEvent
+        
+        if let dataEvent = dataEventAfterViewEnd {
+            #expect(dataEvent.videoData?.videoSourceUrl != firstURL, "Data event after viewEnd should have a different URL")
+        }
+    }
+    
     @Test func vodPlaybackTest() async throws {
         let playerName = "vodPlayer \(UUID().uuidString)"
         MUXSDKCore.swizzleDispatchEvents()
         defer {
             MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
         }
-
+        
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
         let VOD_URL = "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
         let avPlayer = AVPlayer(url: URL(string: VOD_URL)!)
         binding.attach(avPlayer)
-                
+        
         // Start playing VoD content
         await assertStartPlaying(with: avPlayer, for: playerName)
-                
+        
         // Wait approximately 5 seconds
         assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
         
@@ -167,15 +215,15 @@ struct IntegrationTests {
         defer {
             MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
         }
-
+        
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
         let LIVE_URL = "https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8"
         let avPlayer = AVPlayer(url: URL(string: LIVE_URL)!)
         binding.attach(avPlayer)
-                
+        
         // Start playing Live content
         await assertStartPlaying(with: avPlayer, for: playerName)
-                
+        
         // Wait approximately 10 seconds
         assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
         
@@ -208,14 +256,14 @@ struct IntegrationTests {
         let playerName = "offMainThreadPlayerName \(UUID().uuidString)"
         MUXSDKCore.swizzleDispatchEvents()
         MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
-
+        
         let LIVE_URL = "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
         let avPlayer = AVPlayer(url: URL(string: LIVE_URL)!)
         let playerViewController = await MainActor.run {
             AVPlayerViewController()
         }
         var binding: MockAVPlayerViewControllerBinding!
-
+        
         binding = MockAVPlayerViewControllerBinding(
             playerName: playerName,
             softwareName: "TestSoftwareName",
@@ -223,17 +271,17 @@ struct IntegrationTests {
             playerViewController: playerViewController
         )
         binding.attach(avPlayer)
-
+        
         // Call play in background thread
         DispatchQueue.global(qos: .background).async {
             let isMain = Thread.isMainThread
             let isMultiThreaded = Thread.isMultiThreaded()
             #expect(isMultiThreaded, "Expected this code to run multi threaded")
             #expect(!isMain, "Expected this code to run off the main thread")
-
+            
             avPlayer.play()
         }
-
+        
         try await Task.sleep(nanoseconds: 5_000_000_000) // 5 seconds in nanoseconds
         #expect(binding.didReturnNil, "Expected getViewBounds to return empty CGRect")
     }
@@ -260,12 +308,44 @@ struct IntegrationTests {
             let duration = avPlayer.currentItem?.asset.duration
             return CMTimeGetSeconds(duration!)
         }
-
+        
         // Seek to approximately 10 seconds before the end of the content
         let seekTime = CMTime(seconds: vodDurationSeconds - 10.0, preferredTimescale: 1000)
         await avPlayer.seek(to: seekTime)
         
         // Assert that content has ended
         assertFinishPlaying(timeLeft: 10.0, with: avPlayer, for: playerName)
+    }
+    
+    @Test func changingSourceTest() async throws {
+        let playerName = "changingSourcePlayer \(UUID().uuidString)"
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
+        let FIRST_VIDEO_URL = "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
+        let SECOND_VIDEO_URL = "https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8"
+        let avPlayer = AVPlayer(url: URL(string: FIRST_VIDEO_URL)!)
+        binding.attach(avPlayer)
+        
+        // Begin playback of first content title
+        await assertStartPlaying(with: avPlayer, for: playerName)
+        
+        // Wait 5 seconds
+        assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
+        
+        // Select a different content title
+        assertChangeVideoSource(from: FIRST_VIDEO_URL, to: SECOND_VIDEO_URL, with: avPlayer, for: playerName)
+        
+        // Start playing the new content
+        await assertStartPlaying(with: avPlayer, for: playerName)
+        
+        // Wait 5 seconds
+        assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
+        
+        binding.detachAVPlayer()
+        
     }
 }


### PR DESCRIPTION
Integration test that analyzes whether the source change was performed correctly.

Test steps:

- Start playing a video (HLS)
- Wait 5 seconds
- Change the Video URL (to a new HLS)
- Play the new video
- Wait 5 second


The test will be successful if when changing the video, a ViewEnd event is triggered and the DataEvents have the new source.

This PR closes [#328](https://github.com/muxinc/psdks_and_dev_rel_team/issues/328)