### PR TITLE
Exit Before Video Start Integration Test

### DIFF
--- a/Fixtures/IntegrationTests/TestPlans/MUXSDKStats.xctestplan
+++ b/Fixtures/IntegrationTests/TestPlans/MUXSDKStats.xctestplan
@@ -37,6 +37,16 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "IntegrationTests",
+            "testFunctions" : [
+              "exitBeforeVideoStartTest()"
+            ]
+          }
+        ]
+      },
       "target" : {
         "containerPath" : "container:IntegrationTests.xcodeproj",
         "identifier" : "7225C9D52D77C2980003066B",


### PR DESCRIPTION
Integration test that analyzes the behavior of the SDK when the user attempts to play content, but exits the view before playback begins.

Test steps:

- Enable a network throttle of 256 Kbps download, unlimited upload
- Begin playback of content
- Wait a small amount of time (in this case 2 seconds)
- Exit the view

The test will be successful if:
- There is a Play event
- There are no Playing events

Notes: 
- The Test is disabled by default, because obviously it fails in normal conditions (throttle disabled)
- The network throttle of 256 Kbps download, unlimited upload was replicated locally by using the Network Link Conditioner tool. It is still to be replicated in the server using SouceLabs.

<img width="629" alt="Captura de pantalla 2025-06-30 a la(s) 4 03 12 p  m" src="https://github.com/user-attachments/assets/8546a8e8-e2d3-4fef-a8c0-0b2229225db1" />