### PR TITLE
Internal imports by default

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,5 +51,6 @@ let package = Package(
 for target in package.targets {
     target.swiftSettings = (target.swiftSettings ?? []) + [
         .enableUpcomingFeature("StrictConcurrency"),
+        .enableUpcomingFeature("InternalImportsByDefault"),
     ]
 }

--- a/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
+++ b/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
@@ -1,11 +1,11 @@
-import AVFoundation
+public import AVFoundation
 import Combine
-import MuxCore
+public import MuxCore
 
 
 @available(iOS 13, tvOS 13, *)
 @objc(MUXSDKPlayerMonitor)
-public class PlayerMonitor: NSObject, ObservableObject {
+public class PlayerMonitor: NSObject {
 
     var allEvents: some Publisher<MUXSDKBaseEvent, Never> {
         allEventsSubject
@@ -15,12 +15,6 @@ public class PlayerMonitor: NSObject, ObservableObject {
 
     private var cancellables = [AnyCancellable]()
 
-    override init() {
-    }
-}
-
-@available(iOS 13, tvOS 13, *)
-extension PlayerMonitor: Cancellable {
     @objc public func cancel() {
         allEventsSubject.send(completion: .finished)
         cancellables.removeAll()


### PR DESCRIPTION
1. Changes "experimental feature" to "upcoming feature" syntax, as these aren't experimental (anymore) but rather opt-in features of Swift 6
2. Enables the "internal imports by default" upcoming feature, so an `import` statement doesn't automatically re-export everything. That's rarely what you want, but when it is necessary, there's always `public import`.
3. Cleans up some unused protocol conformances on `PlayerMonitor` leftover from development.

As an example of where a public import is necessary, consider this API in `PlayerMonitor.swift`:
```swift
@objc public convenience init(player: AVPlayer, onEvent: @Sendable @escaping @MainActor (MUXSDKBaseEvent) -> Void)
```

Firstly, that initializer needs to be `public` so Objective-C can call it. Parameters refer to types from `AVFoundation` and `MuxCore` so those must be publicly imported as well. Reliance on `Combine` is however an implementation detail and none of the public APIs need its types, so it's a regular `import`.