### PR TITLE
add timestamp helpers and validity checks on conversion

### DIFF
--- a/Sources/MUXSDKStatsInternal/MUXSDKPlayerData.swift
+++ b/Sources/MUXSDKStatsInternal/MUXSDKPlayerData.swift
@@ -6,9 +6,10 @@ extension MUXSDKPlayerData {
         self.update(other.toQuery())
     }
 
+    @available(iOS 13, tvOS 13, *)
     func updateWithTiming(_ timing: PlaybackEventTiming) {
-        playerPlayheadTime = timing.mediaTime.seconds as NSNumber
-        playerProgramTime = timing.programDate?.timeIntervalSince1970 as NSNumber?
-        playerLiveEdgeProgramTime = timing.liveEdgeProgramDate?.timeIntervalSince1970 as NSNumber?
+        playerPlayheadTime = timing.mediaTime.muxTimeValue
+        playerProgramTime = timing.programDate?.muxTimeValue
+        playerLiveEdgeProgramTime = timing.liveEdgeProgramDate?.muxTimeValue
     }
 }

--- a/Sources/MUXSDKStatsInternal/MuxTimestampValueConvertible.swift
+++ b/Sources/MUXSDKStatsInternal/MuxTimestampValueConvertible.swift
@@ -1,0 +1,43 @@
+import CoreMedia.CMSync
+import Foundation
+
+protocol MuxTimeValueConvertible {
+    var muxTimeValue: NSNumber? { get }
+}
+
+@available(iOS 13, tvOS 13, *)
+extension Measurement: MuxTimeValueConvertible where UnitType == UnitDuration {
+    var muxTimeValue: NSNumber? {
+        let milliseconds = converted(to: .milliseconds)
+            .value
+            .rounded(.toNearestOrAwayFromZero)
+
+        guard milliseconds.isFinite, let msCount = Int64(exactly: milliseconds) else {
+            return nil
+        }
+
+        return msCount as NSNumber
+    }
+}
+
+@available(iOS 13, tvOS 13, *)
+extension TimeInterval: MuxTimeValueConvertible {
+    var muxTimeValue: NSNumber? {
+        Measurement(value: self, unit: UnitDuration.seconds)
+            .muxTimeValue
+    }
+}
+
+@available(iOS 13, tvOS 13, *)
+extension Date: MuxTimeValueConvertible {
+    var muxTimeValue: NSNumber? {
+        timeIntervalSince1970.muxTimeValue
+    }
+}
+
+@available(iOS 13, tvOS 13, *)
+extension CMTime: MuxTimeValueConvertible {
+    var muxTimeValue: NSNumber? {
+        seconds.muxTimeValue
+    }
+}

--- a/Sources/MUXSDKStatsInternal/PlaybackEventTiming.swift
+++ b/Sources/MUXSDKStatsInternal/PlaybackEventTiming.swift
@@ -37,11 +37,11 @@ extension PlaybackEventTiming {
             programDate: playerItem.currentDate()
                 .flatMap { playerItemProgramDate in
                     let playerItemMediaTime = playerItem.currentTime()
-                    let mediaTimeElapsed = (playerItemMediaTime - variantSwitchEvent.mediaTime).seconds
-                    guard mediaTimeElapsed >= 0 else {
+                    let mediaTimeElapsed = playerItemMediaTime - variantSwitchEvent.mediaTime
+                    guard mediaTimeElapsed.isValid, mediaTimeElapsed >= .zero else {
                         return nil
                     }
-                    return playerItemProgramDate - mediaTimeElapsed
+                    return playerItemProgramDate - mediaTimeElapsed.seconds
                 },
             loadedTimeRanges: variantSwitchEvent.loadedTimeRanges)
     }


### PR DESCRIPTION
Guarantees that timestamp/duration values use milliseconds and avoids nonsense values such as NaN, infinities, undefined values from `CMTime`, etc.

Broken out from #291