### PR TITLE
require unit tests to pass on CI before longer tasks

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,6 +10,7 @@ steps:
     label: ":xcode: Build Package"
     artifact_paths:
       - ".build/artifacts/*.xcresult.zip"
+  - wait
   - command: "./scripts/run-integration-tests.sh"
     label: ":xcode_simulator: Integration Tests"
     artifact_paths:


### PR DESCRIPTION
With this change, longer running tasks (integration tests and sauce labs) will not start until the package builds and unit tests pass. Currently all of these tasks have the same priority, so PRs with failing unit tests will still eat up tons of CI time running the more involved tests.