### PR TITLE
Integration tests and local test server for bandwidth metrics

### DIFF
--- a/Fixtures/IntegrationTests/IntegrationTestHost/Info.plist
+++ b/Fixtures/IntegrationTests/IntegrationTestHost/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict/>
+	</dict>
+</dict>
+</plist>

--- a/Fixtures/IntegrationTests/IntegrationTestHost/IntegrationTestHost.entitlements
+++ b/Fixtures/IntegrationTests/IntegrationTestHost/IntegrationTestHost.entitlements
@@ -2,9 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>

--- a/Fixtures/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
+++ b/Fixtures/IntegrationTests/IntegrationTests.xcodeproj/project.pbxproj
@@ -43,6 +43,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0886F74F2E16EF7D00A6A7CF /* Exceptions for "IntegrationTestHost" folder in "IntegrationTestHost" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 7225C9C42D77C2980003066B /* IntegrationTestHost */;
+		};
 		729027032DB967B700E08127 /* Exceptions for "ObjCTarget" folder in "ObjCTarget" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			publicHeaders = (
@@ -55,6 +62,9 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		7225C9C72D77C2980003066B /* IntegrationTestHost */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				0886F74F2E16EF7D00A6A7CF /* Exceptions for "IntegrationTestHost" folder in "IntegrationTestHost" target */,
+			);
 			path = IntegrationTestHost;
 			sourceTree = "<group>";
 		};
@@ -546,6 +556,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = IntegrationTestHost/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -581,6 +592,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = IntegrationTestHost/Info.plist;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/Fixtures/IntegrationTests/IntegrationTests.xcworkspace/xcshareddata/xcschemes/IntegrationTestHost.xcscheme
+++ b/Fixtures/IntegrationTests/IntegrationTests.xcworkspace/xcshareddata/xcschemes/IntegrationTestHost.xcscheme
@@ -33,6 +33,12 @@
             reference = "container:TestPlans/MUXSDKStats.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/CIPipeline.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/LocalServerTests.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference
@@ -54,6 +60,17 @@
                BlueprintIdentifier = "7225C9DF2D77C2980003066B"
                BuildableName = "UITests.xctest"
                BlueprintName = "UITests"
+               ReferencedContainer = "container:IntegrationTests.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0886FEE22E269B2500A6A7CF"
+               BuildableName = "LocalServerTests.xctest"
+               BlueprintName = "LocalServerTests"
                ReferencedContainer = "container:IntegrationTests.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/Fixtures/IntegrationTests/IntegrationTests/AVPlayer+Helpers.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/AVPlayer+Helpers.swift
@@ -1,0 +1,77 @@
+//
+//  AVPlayer+Helpers.swift
+//  IntegrationTests
+//
+//  Created by Santiago Puppo on 9/7/25.
+//
+import Combine
+
+
+enum PlayerPlaybackError: Error {
+    case failedToPlay
+    case itemFailed(Error?, AVPlayerItemErrorLog?)
+    case noPlayerItem
+    case timeout
+    case unknown
+}
+
+public func waitForPlaybackToStart(
+    with player: AVPlayer,
+    for playerName: String,
+    timeout: TimeInterval = 60.0
+) async throws {
+    var cancellables = [AnyCancellable]()
+    let startTime = Date()
+    
+    debugPrint("\(startTime) - \(playerName) - Waiting for playback to start... ")
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) -> Void in
+        guard let item = player.currentItem else {
+            continuation.resume(throwing: PlayerPlaybackError.noPlayerItem)
+            return
+        }
+        
+        let observer : AnyPublisher<Result<Void, PlayerPlaybackError>, Never> = item
+            .publisher(for: \.status)
+            .filter { $0 != .unknown } // We filter unkown to not throw unwanted PlayerPlaybackError.unknown
+            .tryMap { [weak item] status in
+                guard let item else {
+                    throw PlayerPlaybackError.noPlayerItem
+                }
+                
+                switch status {
+                case .readyToPlay:
+                    return
+                case .failed:
+                    throw PlayerPlaybackError.itemFailed(item.error, item.errorLog())
+                default:
+                    throw PlayerPlaybackError.unknown
+                }
+            }
+            .timeout(
+                .seconds(timeout),
+                scheduler: DispatchQueue.main,
+                customError: { PlayerPlaybackError.timeout as Error }
+            )
+            .map { _ in Result.success(())}
+            .catch { error in
+                let error = error as? PlayerPlaybackError ?? PlayerPlaybackError.unknown
+                return Just(Result.failure(error) as Result<Void, PlayerPlaybackError>)
+            }
+            .eraseToAnyPublisher()
+        
+        cancellables.append(observer
+            .sink { result in
+                let endTime = Date()
+                let seconds = endTime.timeIntervalSince(startTime)
+                switch result {
+                case .success():
+                    print("## Playback started in \(seconds) seconds")
+                    continuation.resume()
+                case .failure(let error):
+                    print("## Playback Failed: \(error) in \(seconds) seconds (Timeout: \(timeout))")
+                    let error = error as PlayerPlaybackError
+                    continuation.resume(throwing: error)
+                }
+            })
+    }
+    }

--- a/Fixtures/IntegrationTests/IntegrationTests/BandwidthMetricEvents.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/BandwidthMetricEvents.swift
@@ -1,0 +1,409 @@
+//
+//  BandwidthMetricEvents.swift
+//  IntegrationTests
+//
+//  Created by Santiago Puppo on 4/7/25.
+//
+
+import Testing
+import Combine
+
+// This is specifically for Sauce Labs, since the tests are being run even if they are excluded in the TestPlan.
+let RUN_SERVER_TESTS_FLAG : Bool = ProcessInfo.processInfo.environment["RUN_SERVER_TESTS_FLAG"]?.elementsEqual("true") ?? false
+
+#if targetEnvironment(simulator)
+@Suite("Bandwidth Metric Events using AVMetrics", .disabled("Needs a real device to publish metrics"))
+#else
+@Suite("Bandwidth Metric Events using AVMetrics", .disabled(if: !RUN_SERVER_TESTS_FLAG, "Tests are disabled for CI until we have a Swift server"))
+#endif
+struct BandwidthMetricEvents {
+    struct NotSupportedError : Error {}
+    
+    let DEFAULT_TEST_WAIT_TIME = 5
+    
+    let host = ProcessInfo.processInfo.environment["TEST_HOST"] ?? "localhost"
+    let port = ProcessInfo.processInfo.environment["TEST_PORT"] ?? "8080"
+    let baseUrl : URL
+    
+    init() async throws {
+        baseUrl = URL(string: "http://" + host + ":" + port)!
+    }
+    
+    func getTestUrl(_ path : String) throws -> URL  {
+        if #available(iOS 16.0, tvOS 16.0, *) {
+            return baseUrl.appending(path: path)
+        } else {
+            throw NotSupportedError()
+        }
+    }
+    
+    func getRequestEvents(for playerName : String) -> [MUXSDKRequestBandwidthEvent] {
+        getEvents(for: playerName).compactMap { event in
+            return event as? MUXSDKRequestBandwidthEvent
+        }
+    }
+    
+    func commonExpectations(for completedEvents: [MUXSDKRequestBandwidthEvent])
+    {
+        let bandwidthMetricData = completedEvents.compactMap(\.bandwidthMetricData)
+
+        let requestUrls = bandwidthMetricData.compactMap(\.requestUrl)
+        let requestHostNames = bandwidthMetricData.compactMap(\.requestHostName)
+        let orderedTimes = bandwidthMetricData.compactMap {
+            [$0.requestStart, $0.requestResponseStart, $0.requestResponseEnd]
+                .compactMap { $0 as? Int64 }
+                .map { Date(milliseconds: $0) }
+        }
+        
+        #expect(requestUrls.toBeUnique())
+        #expect(requestUrls.allSatisfy { $0.starts(with: self.baseUrl.absoluteString) })
+        #expect(requestHostNames.allSatisfy { $0 == self.host })
+        #expect(
+            orderedTimes.allSatisfy {
+                $0.count == 3 &&
+                $0.toBeSorted(by: {
+                    $0.compare($1) == .orderedAscending ||
+                    $0.compare($1) == .orderedSame
+                })
+            }
+        )
+    }
+    
+    @available(iOS 16.0, tvOS 16.0, *)
+    func setUpTest(for playerName: String, testCase: String) async throws -> AVPlayer {
+        let vodURL = try getTestUrl(testCase)
+        
+        let avPlayer = AVPlayer()
+        avPlayer.isMuted = true
+        
+        await MainActor.run(body: {
+            let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
+            binding.attach(avPlayer)
+        })
+        
+        try await Task.sleep(for: .seconds(1))
+        
+        await MainActor.run(body: {
+            let asset = AVURLAsset(url: vodURL)
+            let playerItem = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: [])
+            avPlayer.replaceCurrentItem(with: playerItem)
+        })
+        return avPlayer
+    }
+    
+    @available(iOS 16.0, tvOS 16.0, *)
+    func playAndWait(for playerName : String, player avPlayer: AVPlayer) async throws -> [MUXSDKRequestBandwidthEvent] {
+        do {
+            await avPlayer.play()
+            try await waitForPlaybackToStart(with: avPlayer, for: playerName)
+            try await Task.sleep(for: .seconds(DEFAULT_TEST_WAIT_TIME))
+        } catch {
+            Issue.record("Playback did not start")
+        }
+        return getRequestEvents(for: playerName)
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("Standard TS Stream") func standardTSStream() async throws {
+        let testCase = "/test-cases/standard/ts-stream.m3u8"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        let requestEvents =  try await playAndWait(for: playerName, player: avPlayer)
+
+        let completeEvents = requestEvents.completeEvents()
+        let manifestEvents = requestEvents.manifestEvents()
+        let videoEvents = requestEvents.segmentEvents(forType: "video")
+            
+        commonExpectations(for: completeEvents)
+        #expect(completeEvents.count == 5)
+        #expect(manifestEvents.count == 1)
+        #expect(videoEvents.count == 4)
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("Standard CMAF Stream") func standardCmafStream() async throws {
+        let testCase = "/test-cases/cmaf/index.m3u8"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        let requestEvents = try await playAndWait(for: playerName, player: avPlayer)
+        
+        let completeEvents = requestEvents.completeEvents()
+        let manifestEvents = requestEvents.manifestEvents()
+        let videoEvents = requestEvents.segmentEvents(forType: "video")
+        let audioEvents = requestEvents.segmentEvents(forType: "audio")
+        let videoInitEvents = requestEvents.segmentEvents(forType: "video_init")
+        let audioInitEvents = requestEvents.segmentEvents(forType: "audio_init")
+        
+        commonExpectations(for: completeEvents)
+        #expect(completeEvents.count == 14)
+        #expect(manifestEvents.count == 3)
+        #expect(videoEvents.count == 4)
+        #expect(videoInitEvents.count == 1)
+        #expect(audioEvents.count == 5)
+        #expect(audioInitEvents.count == 1)
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("Standard MP4 Stream") func standardMp4Stream() async throws {
+        let testCase = "/test-cases/input.mp4"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        let requestEvents =  try await playAndWait(for: playerName, player: avPlayer)
+                
+        // Should have one complete event created from access log
+        let completeEvents = requestEvents.completeEvents()
+        #expect(completeEvents.count == 1)
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("Standard Multi Variant Stream") func standardMultiVariantStream() async throws {
+        let testCase = "/test-cases/standard/multi-variant.m3u8"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        let requestEvents =  try await playAndWait(for: playerName, player: avPlayer)
+        
+        let completeEvents = requestEvents.completeEvents()
+        let manifestEvents = requestEvents.manifestEvents()
+        let videoEvents = requestEvents.segmentEvents(forType: "video")
+        let manifestNames = manifestEvents.map{$0.bandwidthMetricData?.requestUrl}
+        
+        commonExpectations(for: completeEvents)
+        /*
+         I noticed during testing that multivariant streams may sometimes download all manifests.
+         Mostly when running on repeat
+         */
+        #expect(completeEvents.count == 6 || completeEvents.count == 7)
+        #expect(manifestEvents.count == 2 || manifestEvents.count == 3)
+        #expect(videoEvents.count == 4)
+        #expect(manifestNames.toBeUnique())
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("Standard Encrypted Stream") func standardEncryptedStream() async throws {
+        let testCase = "/test-cases/standard/encrypted-stream.m3u8"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        let requestEvents =  try await playAndWait(for: playerName, player: avPlayer)
+        
+        let completeEvents = requestEvents.completeEvents()
+        let manifestEvents = requestEvents.manifestEvents()
+        let videoEvents = requestEvents.segmentEvents(forType: "video")
+        let contentKeyEvents = requestEvents.encryptionEvents()
+        
+        commonExpectations(for: completeEvents)
+        #expect(completeEvents.count == 6)
+        #expect(manifestEvents.count == 1)
+        #expect(videoEvents.count == 4)
+        #expect(contentKeyEvents.count == 1)
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("Failed Requests Test Stream") func requestFailedStream() async throws {
+        let testCase = "/test-cases/http-codes/request-failed-stream.m3u8"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        let requestEvents =  try await playAndWait(for: playerName, player: avPlayer)
+        
+        let completeEvents = requestEvents.completeEvents()
+        let manifestEvents = requestEvents.manifestEvents()
+        let videoEvents = requestEvents.segmentEvents(forType: "video")
+        let failedEvents = requestEvents.failedEvents()
+        
+        commonExpectations(for: completeEvents)
+        #expect(requestEvents.count == 5)
+        #expect(completeEvents.count == 2)
+        #expect(failedEvents.count == 3)
+        
+        #expect(manifestEvents.count == 1)
+        #expect(videoEvents.count == 4)
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("Redirected Requests Test Stream") func requestRedirectedStream() async throws {
+        let testCase = "/redirect/test-cases/http-codes/redirected-stream.m3u8"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        let requestEvents =  try await playAndWait(for: playerName, player: avPlayer)
+        
+        let completeEvents = requestEvents.completeEvents()
+        let manifestEvents = requestEvents.manifestEvents()
+        let videoEvents = requestEvents.segmentEvents(forType: "video")
+        
+        commonExpectations(for: completeEvents)
+        #expect(completeEvents.count == 3)
+        #expect(manifestEvents.count == 1)
+        #expect(videoEvents.count == 2)
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("Canceled Request Stream", .disabled("Couldn't figure how to forcefully cancel a request")) func requestCanceledStream() async throws {
+        let testCase = "/test-cases/http-codes/request-canceled-stream.m3u8"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        await avPlayer.play()
+        try await waitForPlaybackToStart(with: avPlayer, for: playerName)
+        try await Task.sleep(for: .seconds(DEFAULT_TEST_WAIT_TIME))
+        try await MainActor.run(body: {
+            let newURL = try getTestUrl("/not-found/this-stream-doesnt-exist.m3u8")
+            let asset = AVURLAsset(url: newURL)
+            let playerItem = AVPlayerItem(asset: asset, automaticallyLoadedAssetKeys: [])
+            avPlayer.replaceCurrentItem(with: playerItem)
+        })
+        try await Task.sleep(for: .seconds(2))
+        
+        let requestEvents = getRequestEvents(for: playerName)
+        
+        let completeEvents = requestEvents.completeEvents()
+        let canceledEvents = requestEvents.canceledEvents()
+        
+        commonExpectations(for: completeEvents)
+        #expect(completeEvents.count == 3)
+        #expect(canceledEvents.count == 1)
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @available(iOS, introduced: 18.0, message: "Needs AVMetrics to run")
+    @Test("CDN Change Stream") func cdnChangeStream() async throws {
+        let testCase = "/test-cases/cdn-change/index.m3u8"
+        let playerName = "\(testCase) \(UUID().uuidString)"
+        
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let avPlayer = try await setUpTest(for: playerName, testCase: testCase)
+        let requestEvents =  try await playAndWait(for: playerName, player: avPlayer)
+        
+        let completeEvents = requestEvents.completeEvents()
+        let failedEvents = requestEvents.failedEvents()
+        let manifestEvents = requestEvents.manifestEvents()
+        let videoEvents = requestEvents.segmentEvents(forType: "video")
+        let cdnHeaders = videoEvents
+            .compactMap { $0.bandwidthMetricData?.requestResponseHeaders }
+            .compactMap { $0["x-cdn"] as? String }
+        
+        commonExpectations(for: completeEvents)
+        #expect(completeEvents.count == 8)
+        #expect(failedEvents.count == 1)
+        #expect(manifestEvents.count == 3)
+        #expect(videoEvents.count == 6)
+        #expect(cdnHeaders.count == (videoEvents.count - failedEvents.count))
+        #expect(cdnHeaders == ["cdnA", "cdnB", "cdnB", "cdnB", "cdnB"])
+        
+        /*
+        * As long as we swizzleDispatchEvents we wont be able to correctly test this
+        * since that event is fired from core. It also wouldn't make sense to dispatch
+        * the event from here just for the test.
+        *
+        * This is an idea of what the assertion should look like
+        */
+        /*let cdnChangeEvents = getEvents(for: playerName)
+            .filter{ $0.getType() == MUXSDKPlaybackEventCDNChangeEventType }
+            .compactMap { $0 as? MUXSDKPlaybackEvent }
+
+        #expect(cdnChangeEvents.count == 2) // or 1 if we ignore nil -> cdn1
+        if cdnChangeEvents.count == 2,
+            let firstCdnChangeVideoData = cdnChangeEvents[0].videoData,
+            let secondCdnChangeVideoData = cdnChangeEvents[1].videoData
+        {
+            #expect(firstCdnChangeVideoData.videoPreviousCDN == nil)
+            #expect(firstCdnChangeVideoData.videoCDN == "cdnA")
+            // Just these two if count == 1
+            #expect(secondCdnChangeVideoData.videoPreviousCDN == "cdnA")
+            #expect(secondCdnChangeVideoData.videoCDN == "cdnB")
+        }*/
+    }
+}
+
+extension Array where Element: MUXSDKRequestBandwidthEvent {
+    func completeEvents() -> [MUXSDKRequestBandwidthEvent] {
+        filter { $0.type == MUXSDKPlaybackEventRequestBandwidthEventCompleteType }
+    }
+    
+    func failedEvents() -> [MUXSDKRequestBandwidthEvent] {
+        filter { $0.type == MUXSDKPlaybackEventRequestBandwidthEventErrorType }
+    }
+    
+    func canceledEvents() -> [MUXSDKRequestBandwidthEvent] {
+        filter { $0.type == MUXSDKPlaybackEventRequestBandwidthEventCancelType }
+    }
+    
+    func manifestEvents() -> [MUXSDKRequestBandwidthEvent] {
+        filter{ $0.bandwidthMetricData?.requestType == "manifest" }
+    }
+        
+    func segmentEvents(forType requestType : String) -> [MUXSDKRequestBandwidthEvent] {
+        filter{ $0.bandwidthMetricData?.requestType == requestType }
+    }
+    
+    func encryptionEvents() -> [MUXSDKRequestBandwidthEvent] {
+        filter { $0.bandwidthMetricData?.requestType == "encryption" }
+    }
+    
+    func print() {
+        map {ev in "\(ev.type!) - \(ev.bandwidthMetricData!.requestUrl!)"}
+            .forEach { Swift.print($0 + "\n") }
+    }
+}
+
+extension Array where Element : Hashable {
+    func toBeUnique() -> Bool {
+        Set(self).count == self.count
+    }
+    
+    func toBeSorted(by: (Element, Element) throws -> Bool) rethrows -> Bool where Element : Hashable {
+       try self.sorted(by: by) == self
+    }
+}

--- a/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Combine
 @testable import MUXSDKStats
 
 @Suite
@@ -6,28 +7,13 @@ struct IntegrationTests {
     let dispatchDelay = 3.0
     let msTolerance: Double = 2000
     
-    func getLastTimestamp(for playerName: String) -> NSNumber? {
-        return MUXSDKCore.getPlayheadTimeStamps(forPlayer: playerName).last
-    }
-    
-    func getTimeDeltas(for playerName: String) -> [NSNumber] {
-        return MUXSDKCore.getPlayheadTimeDeltas(forPlayer: playerName)
-    }
-    
-    func getEventsAndReset(for playerName: String) -> [MUXSDKBaseEvent]? {
-        defer {
-            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
-        }
-        return MUXSDKCore.getEventsForPlayer(playerName)
-    }
-    
     func assertStartPlaying(with player: AVPlayer, for playerName: String) async {
         NSLog("## Start playing content")
         await MainActor.run {
             player.play()
         }
-        try? await Task.sleep(nanoseconds: UInt64(dispatchDelay * 1_000_000_000))
-        
+        try? await Task.sleep(seconds: dispatchDelay)
+
         let events = getEventsAndReset(for: playerName)
         
         let containsPlayEvent = events?.contains { $0 is MUXSDKPlayEvent } ?? false
@@ -38,8 +24,12 @@ struct IntegrationTests {
     
     func assertWaitForNSeconds(n seconds: Double, with player: AVPlayer, for playerName: String) {
         NSLog("## Wait approximately \(seconds) seconds")
-        let waitTimeBefore = getLastTimestamp(for: playerName)!.doubleValue
+        var waitTimeBefore = getLastTimestamp(for: playerName)?.doubleValue
         let beforeTimePlayer = player.currentTime().seconds
+        if (waitTimeBefore == nil) {
+            Issue.record("Could not find any timestamp before waiting, setting to \(beforeTimePlayer)")
+            waitTimeBefore = beforeTimePlayer
+        }
         
         var currentTimePlayer = player.currentTime().seconds
         var waitedTime = 0.0
@@ -55,7 +45,7 @@ struct IntegrationTests {
         }
         
         let waitTimeAfter = getLastTimestamp(for: playerName)!.doubleValue
-        let waitTimeDiff = waitTimeAfter - waitTimeBefore
+        let waitTimeDiff = waitTimeAfter - waitTimeBefore!
         let lowerBound = (seconds * 1000) - msTolerance
         let upperBound = (seconds * 1000) + msTolerance
         
@@ -65,12 +55,19 @@ struct IntegrationTests {
     
     func assertPauseForNSeconds(n seconds: Double, with player: AVPlayer, for playerName: String) async {
         NSLog("## Pause the content for \(seconds) seconds")
-        let waitTimeBefore = getLastTimestamp(for: playerName)!.doubleValue
         await MainActor.run {
             player.pause()
         }
-        try? await Task.sleep(nanoseconds: UInt64(dispatchDelay * 1_000_000_000))
-        let waitTimeAfter = getLastTimestamp(for: playerName)!.doubleValue
+        try? await Task.sleep(seconds: dispatchDelay)
+        
+        let waitTimeBefore = getLastTimestamp(for: playerName)?.doubleValue ?? 0
+        try? await Task.sleep(seconds: seconds)
+        let waitTimeAfter = getLastTimestamp(for: playerName)?.doubleValue
+        
+        guard let waitTimeAfter = waitTimeAfter else {
+            Issue.record("Unexpectedly received no timestamp after pausing for \(seconds) seconds")
+            return
+        }
         
         let waitTimeDiff = waitTimeAfter - waitTimeBefore
         // Expect that time difference is approximately 0 seconds
@@ -167,13 +164,13 @@ struct IntegrationTests {
         }
         
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
-        let VOD_URL = "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
+        let VOD_URL = "https://stream.mux.com/VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA.m3u8"
         let avPlayer = AVPlayer(url: URL(string: VOD_URL)!)
         binding.attach(avPlayer)
         
         // Start playing VoD content
         await assertStartPlaying(with: avPlayer, for: playerName)
-        
+        try await waitForPlaybackToStart(with: avPlayer, for: playerName)
         // Wait approximately 5 seconds
         assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
         
@@ -216,7 +213,8 @@ struct IntegrationTests {
         
         // Start playing Live content
         await assertStartPlaying(with: avPlayer, for: playerName)
-        
+        try await waitForPlaybackToStart(with: avPlayer, for: playerName)
+                
         // Wait approximately 10 seconds
         assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
         
@@ -274,8 +272,8 @@ struct IntegrationTests {
             
             avPlayer.play()
         }
-        
-        try await Task.sleep(nanoseconds: 5_000_000_000) // 5 seconds in nanoseconds
+
+        try await Task.sleep(seconds: 5)
         #expect(binding.didReturnNil, "Expected getViewBounds to return empty CGRect")
     }
     
@@ -287,12 +285,13 @@ struct IntegrationTests {
         }
         
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
-        let VOD_URL = "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
+        let VOD_URL = "https://stream.mux.com/VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA.m3u8"
         let avPlayer = AVPlayer(url: URL(string: VOD_URL)!)
         binding.attach(avPlayer)
         
         // Start playing content
         await assertStartPlaying(with: avPlayer, for: playerName)
+        try await waitForPlaybackToStart(with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
         assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
@@ -442,6 +441,71 @@ struct IntegrationTests {
             actualWatchTimeSeconds >= expectedPlaybackTime - tolerance &&
             actualWatchTimeSeconds <= expectedPlaybackTime + tolerance,
             "Watch time should be approximately \(expectedPlaybackTime) seconds (±\(tolerance)s), but was \(actualWatchTimeSeconds) seconds"
+        )
+    }
+    
+    @available(iOS 18.0, tvOS 18.0, visionOS 2.0, *)
+    @Test func bandwidthMetricEventTests() async throws {
+        let playerName = "bandwidthMetricEvent \(UUID().uuidString)"
+        MUXSDKCore.swizzleDispatchEvents()
+        defer {
+            MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+        }
+        
+        let binding = MUXSDKPlayerBinding(
+            playerName: playerName,
+            softwareName: "TestSoftwareName",
+            softwareVersion: "TestSoftwareVersion"
+        )
+        // from https://github.com/muxinc/elements/blob/main/shared/assets/media-assets.json
+        let VOD_URL = URL(
+            string:
+                "https://stream.mux.com/VcmKA6aqzIzlg3MayLJDnbF55kX00mds028Z65QxvBYaA.m3u8"
+        )!
+        let avPlayer = AVPlayer(url: VOD_URL)
+        binding.attach(avPlayer)
+
+        // Start playing content
+        //await assertStartPlaying(with: avPlayer, for: playerName)
+        await MainActor.run {
+            avPlayer.play()
+        }
+        try await waitForPlaybackToStart(with: avPlayer, for: playerName)
+        try? await Task.sleep(seconds: dispatchDelay)
+
+        assertWaitForNSeconds(n: 1, with: avPlayer, for: playerName)
+        
+        let completeRequestEvents = MUXSDKCore.getEventsForPlayer(playerName)
+            .filter {
+                $0.getType()
+                    == MUXSDKPlaybackEventRequestBandwidthEventCompleteType
+            }
+            .compactMap { $0 as? MUXSDKPlaybackEvent }
+        #expect(completeRequestEvents.count > 0)
+#if !targetEnvironment(simulator)
+        let manifestEvents = completeRequestEvents
+            .filter { $0.bandwidthMetricData?.requestType == "manifest" }
+        let videoEvents = completeRequestEvents
+            .filter { $0.bandwidthMetricData?.requestType == "video" }
+
+        #expect(manifestEvents.count > 0, "No manifest events found")
+        #expect(videoEvents.count > 0, "No video events found")
+
+        if let mainManifest = manifestEvents.first,
+           let bandwidthMetricData = mainManifest.bandwidthMetricData
+        {
+            #expect(bandwidthMetricData.requestHostName == VOD_URL.host())
+            #expect(bandwidthMetricData.requestResponseHeaders?.isEmpty == false)
+            #expect(bandwidthMetricData.requestResponseHeaders?.index(forKey: "x-cdn") != nil)
+        }
+#endif
+    }
+}
+
+extension Task where Success == Never, Failure == Never {
+    static func sleep(seconds: Double) async throws {
+        return try await Task.sleep(
+            nanoseconds: UInt64(seconds * 1_000_000_000)
         )
     }
 }

--- a/Fixtures/IntegrationTests/IntegrationTests/MUXSDKCoreDelegate.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/MUXSDKCoreDelegate.swift
@@ -1,0 +1,25 @@
+//
+//  MUXSDKStatsCoreDelegate.swift
+//  IntegrationTests
+//
+//  Created by Santiago Puppo on 8/7/25.
+//
+
+public func getLastTimestamp(for playerName: String) -> NSNumber? {
+    return MUXSDKCore.getPlayheadTimeStamps(forPlayer: playerName).last
+}
+
+public func getTimeDeltas(for playerName: String) -> [NSNumber] {
+    return MUXSDKCore.getPlayheadTimeDeltas(forPlayer: playerName)
+}
+
+public func getEventsAndReset(for playerName: String) -> [MUXSDKBaseEvent]? {
+    defer {
+        MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
+    }
+    return MUXSDKCore.getEventsForPlayer(playerName)
+}
+
+public func getEvents(for playerName: String) -> [MUXSDKBaseEvent] {
+    return MUXSDKCore.getEventsForPlayer(playerName)
+}

--- a/Fixtures/IntegrationTests/Mocks/MockAVPlayerViewControllerBinding.h
+++ b/Fixtures/IntegrationTests/Mocks/MockAVPlayerViewControllerBinding.h
@@ -9,6 +9,6 @@
 
 @interface MockAVPlayerViewControllerBinding : MUXSDKAVPlayerViewControllerBinding
 
-@property (nonatomic, assign) BOOL didReturnNil;
+@property (atomic, assign) BOOL didReturnNil;
 
 @end

--- a/Fixtures/IntegrationTests/TestPlans/CIPipeline.xctestplan
+++ b/Fixtures/IntegrationTests/TestPlans/CIPipeline.xctestplan
@@ -9,7 +9,9 @@
     }
   ],
   "defaultOptions" : {
+    "environmentVariableEntries" : [
 
+    ]
   },
   "testTargets" : [
     {
@@ -27,6 +29,13 @@
       }
     },
     {
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "BandwidthMetricEvents"
+          }
+        ]
+      },
       "target" : {
         "containerPath" : "container:IntegrationTests.xcodeproj",
         "identifier" : "7225C9D52D77C2980003066B",

--- a/Fixtures/IntegrationTests/TestPlans/LocalServerTests.xctestplan
+++ b/Fixtures/IntegrationTests/TestPlans/LocalServerTests.xctestplan
@@ -1,0 +1,54 @@
+{
+  "configurations" : [
+    {
+      "id" : "ACDDCF23-BC98-4C54-BB12-DC5A34F3C6C3",
+      "name" : "Retry on Failure",
+      "options" : {
+        "maximumTestRepetitions" : 5,
+        "repeatInNewRunnerProcess" : true,
+        "testRepetitionMode" : "retryOnFailure"
+      }
+    },
+    {
+      "id" : "A45F1A3C-FC11-4AAD-B9DD-B25BA88A8E30",
+      "name" : "Run once",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "RUN_SERVER_TESTS_FLAG",
+        "value" : "true"
+      },
+      {
+        "key" : "TEST_HOST",
+        "value" : "localhost"
+      },
+      {
+        "key" : "TEST_PORT",
+        "value" : "8080"
+      }
+    ],
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : {
+        "suites" : [
+          {
+            "name" : "IntegrationTests"
+          }
+        ]
+      },
+      "target" : {
+        "containerPath" : "container:IntegrationTests.xcodeproj",
+        "identifier" : "7225C9D52D77C2980003066B",
+        "name" : "IntegrationTests"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
This reverts commit 3ee94883406390569d5e013fdf5d8f92aa154b87 with the in-progress integration test server. Original PR text follows.

> For testing I used a [Local Server](https://github.com/muxinc/network-api-fixture-server/tree/main/network-api-fixture-server), which is documented [here](https://www.notion.so/mux/Test-Fixture-Server-23397a7f89d080a3ac60f1cdc1ffb922#23397a7f89d080b181d6d35a1201054f). The purpose of this server is to control different network conditions so that we can test that the events are created successfully. I had to modify Integration Test Host capabilities to allow incoming and outgoing connections for App Sandbox to run tests in Mac Catalyst (and possibly real devices too)
>
> I also added some random fixes in the Integration Tests suite to try to fix some issues that were causing random fails and reorganized some functions to reuse across tests. Main function being waitForPlaybackToStart, which we should add to most existing tests. 
>
> Added a new test plan, LocalServerTests, to run specifically the new suite of tests that requires the new local server. That test plan holds two environment variables TEST_HOST and TEST_PORT, defaulted to localhost:8080, but open to modification. The other test plans exclude this new test suite, however this is apparently ignored by SauceLabs, and also Sauce Labs doesn´t allow env variables in real devices, hence why I added RUN_SERVER_TESTS_FLAG
