### PR TITLE
Fix crash & simplify access log URI handling

### DIFF
--- a/Fixtures/UnitTests/UnitTests.xcodeproj/project.pbxproj
+++ b/Fixtures/UnitTests/UnitTests.xcodeproj/project.pbxproj
@@ -8,14 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		08191E252DC12B8F003F912A /* MUXSDKStats in Frameworks */ = {isa = PBXBuildFile; productRef = 08191E242DC12B8F003F912A /* MUXSDKStats */; };
-		08191E352DC12EE8003F912A /* MUXSDKPlayerBindingManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 08191E2D2DC12EE7003F912A /* MUXSDKPlayerBindingManager.h */; };
-		08191E362DC12EE8003F912A /* MUXSDKCustomerViewDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 08191E2E2DC12EE7003F912A /* MUXSDKCustomerViewDataStore.h */; };
-		08191E372DC12EE8003F912A /* MUXSDKCustomerPlayerDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 08191E2F2DC12EE7003F912A /* MUXSDKCustomerPlayerDataStore.h */; };
-		08191E382DC12EE8003F912A /* MUXSDKPlayerBindingConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 08191E302DC12EE7003F912A /* MUXSDKPlayerBindingConstants.h */; };
-		08191E392DC12EE8003F912A /* MUXSDKCustomerVideoDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 08191E312DC12EE7003F912A /* MUXSDKCustomerVideoDataStore.h */; };
-		08191E3A2DC12EE8003F912A /* include in Headers */ = {isa = PBXBuildFile; fileRef = 08191E322DC12EE8003F912A /* include */; };
-		08191E3B2DC12EE8003F912A /* MUXSDKConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = 08191E332DC12EE8003F912A /* MUXSDKConnection.h */; };
-		08191E3C2DC12EE8003F912A /* MUXSDKCustomerCustomDataStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 08191E342DC12EE8003F912A /* MUXSDKCustomerCustomDataStore.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -31,14 +23,6 @@
 /* Begin PBXFileReference section */
 		0812BF672DC119F2004F921E /* UnitTestsHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = UnitTestsHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0812BF752DC119F4004F921E /* UnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		08191E2D2DC12EE7003F912A /* MUXSDKPlayerBindingManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKPlayerBindingManager.h; path = ../../../Sources/MUXSDKStats/MUXSDKPlayerBindingManager.h; sourceTree = "<group>"; };
-		08191E2E2DC12EE7003F912A /* MUXSDKCustomerViewDataStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKCustomerViewDataStore.h; path = ../../../Sources/MUXSDKStats/MUXSDKCustomerViewDataStore.h; sourceTree = "<group>"; };
-		08191E2F2DC12EE7003F912A /* MUXSDKCustomerPlayerDataStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKCustomerPlayerDataStore.h; path = ../../../Sources/MUXSDKStats/MUXSDKCustomerPlayerDataStore.h; sourceTree = "<group>"; };
-		08191E302DC12EE7003F912A /* MUXSDKPlayerBindingConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKPlayerBindingConstants.h; path = ../../../Sources/MUXSDKStats/MUXSDKPlayerBindingConstants.h; sourceTree = "<group>"; };
-		08191E312DC12EE7003F912A /* MUXSDKCustomerVideoDataStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKCustomerVideoDataStore.h; path = ../../../Sources/MUXSDKStats/MUXSDKCustomerVideoDataStore.h; sourceTree = "<group>"; };
-		08191E322DC12EE8003F912A /* include */ = {isa = PBXFileReference; lastKnownFileType = folder; name = include; path = ../../../Sources/MUXSDKStats/include; sourceTree = "<group>"; };
-		08191E332DC12EE8003F912A /* MUXSDKConnection.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKConnection.h; path = ../../../Sources/MUXSDKStats/MUXSDKConnection.h; sourceTree = "<group>"; };
-		08191E342DC12EE8003F912A /* MUXSDKCustomerCustomDataStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = MUXSDKCustomerCustomDataStore.h; path = ../../../Sources/MUXSDKStats/MUXSDKCustomerCustomDataStore.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -99,7 +83,6 @@
 			children = (
 				08191E552DC155B2003F912A /* Configuration */,
 				08191E4E2DC14F27003F912A /* UnitTestsHost */,
-				08191E3D2DC145D0003F912A /* Headers */,
 				08191D902DC11EDA003F912A /* UnitTests */,
 				08191DCA2DC1215D003F912A /* Frameworks */,
 				0812BF682DC119F2004F921E /* Products */,
@@ -130,21 +113,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		08191E3D2DC145D0003F912A /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				08191E322DC12EE8003F912A /* include */,
-				08191E332DC12EE8003F912A /* MUXSDKConnection.h */,
-				08191E342DC12EE8003F912A /* MUXSDKCustomerCustomDataStore.h */,
-				08191E2F2DC12EE7003F912A /* MUXSDKCustomerPlayerDataStore.h */,
-				08191E312DC12EE7003F912A /* MUXSDKCustomerVideoDataStore.h */,
-				08191E2E2DC12EE7003F912A /* MUXSDKCustomerViewDataStore.h */,
-				08191E302DC12EE7003F912A /* MUXSDKPlayerBindingConstants.h */,
-				08191E2D2DC12EE7003F912A /* MUXSDKPlayerBindingManager.h */,
-			);
-			path = Headers;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -152,14 +120,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				08191E352DC12EE8003F912A /* MUXSDKPlayerBindingManager.h in Headers */,
-				08191E362DC12EE8003F912A /* MUXSDKCustomerViewDataStore.h in Headers */,
-				08191E372DC12EE8003F912A /* MUXSDKCustomerPlayerDataStore.h in Headers */,
-				08191E382DC12EE8003F912A /* MUXSDKPlayerBindingConstants.h in Headers */,
-				08191E392DC12EE8003F912A /* MUXSDKCustomerVideoDataStore.h in Headers */,
-				08191E3A2DC12EE8003F912A /* include in Headers */,
-				08191E3B2DC12EE8003F912A /* MUXSDKConnection.h in Headers */,
-				08191E3C2DC12EE8003F912A /* MUXSDKCustomerCustomDataStore.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -512,6 +472,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"../../Sources/MUXSDKStats\"",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
@@ -534,6 +498,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"../../Sources/MUXSDKStats\"",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;

--- a/Sources/MUXSDKStats/MUXSDKBandwidthMetricData+MUXSDKAccessLog.m
+++ b/Sources/MUXSDKStats/MUXSDKBandwidthMetricData+MUXSDKAccessLog.m
@@ -1,7 +1,5 @@
 #import "MUXSDKBandwidthMetricData+MUXSDKAccessLog.h"
 
-#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
-
 @implementation MUXSDKBandwidthMetricData (MUXSDKAccessLog)
 
 - (void)updateURLPropertiesAndRequestTypeWithRequestURI:(nullable NSString *)requestURI {
@@ -15,23 +13,27 @@
     // This is not always going to work, as it's perfectly in-spec to set content type headers instead.
     // Also the access log tends to only report playlist requests anyway. See AVMetrics for useful data.
     NSString *pathExtension = components.path.pathExtension;
-    if (@available(iOS 14.0, tvOS 14.0, *)) {
-        UTType *inferredType = [UTType typeWithFilenameExtension:pathExtension];
-        if ([inferredType conformsToType:UTTypeVideo]) {
-            self.requestType = @"video";
-        } else if ([inferredType conformsToType:UTTypeAudio]) {
-            self.requestType = @"audio";
-        } else if ([inferredType conformsToType:UTTypeAudiovisualContent]) {
-            self.requestType = @"media";
-        } else if ([inferredType conformsToType:UTTypePlaylist]) {
-            self.requestType = @"manifest";
-        }
+    if (pathExtension) {
+        static NSDictionary<NSString *, NSString *> *lookup;
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            lookup = @{
+                @"m3u8": @"manifest",
+                @"m3u": @"manifest",
+
+                @"ts": @"media",
+                @"mp4": @"media",
+                @"mov": @"media",
+
+                @"aac": @"audio",
+                @"ac3": @"audio",
+                @"m4a": @"audio",
+                @"mp3": @"audio",
+            };
+        });
+        self.requestType = lookup[pathExtension];
     } else {
-        if ([pathExtension isEqual:@"m3u8"] || [pathExtension isEqual:@"m3u"]) {
-            self.requestType = @"manifest";
-        } else if ([pathExtension isEqual:@"ts"] || [pathExtension isEqual:@"mp4"]) {
-            self.requestType = @"media";
-        }
+        self.requestType = nil;
     }
 }
 

--- a/Tests/MUXSDKStatsTests/MUXSDKBandwidthMetricDataTests.m
+++ b/Tests/MUXSDKStatsTests/MUXSDKBandwidthMetricDataTests.m
@@ -1,0 +1,94 @@
+#import <XCTest/XCTest.h>
+#import "MUXSDKBandwidthMetricData+MUXSDKAccessLog.h"
+
+@interface MUXSDKBandwidthMetricDataTests : XCTestCase
+
+@end
+
+@implementation MUXSDKBandwidthMetricDataTests
+
+- (void)testNilURI {
+    MUXSDKBandwidthMetricData *metricData = [MUXSDKBandwidthMetricData new];
+    [metricData updateURLPropertiesAndRequestTypeWithRequestURI:nil];
+
+    XCTAssertNil(metricData.requestUrl);
+    XCTAssertNil(metricData.requestHostName);
+    XCTAssertNil(metricData.requestType);
+}
+
+- (void)testMissingExtension {
+    NSString *uri = @"https://example.com/no_extension";
+
+    MUXSDKBandwidthMetricData *metricData = [MUXSDKBandwidthMetricData new];
+    [metricData updateURLPropertiesAndRequestTypeWithRequestURI:uri];
+
+    XCTAssertEqualObjects(metricData.requestUrl, uri);
+    XCTAssertEqualObjects(metricData.requestHostName, @"example.com");
+    XCTAssertNil(metricData.requestType);
+}
+
+- (void)testInvalidBeginningOfURI {
+    NSString *uri = @"https:/example.com/playlist.m3u8";
+
+    MUXSDKBandwidthMetricData *metricData = [MUXSDKBandwidthMetricData new];
+    [metricData updateURLPropertiesAndRequestTypeWithRequestURI:uri];
+
+    XCTAssertEqualObjects(metricData.requestUrl, uri);
+    XCTAssertEqualObjects(metricData.requestHostName, uri);
+    XCTAssertEqualObjects(metricData.requestType, @"manifest");
+}
+
+- (void)testNonsenseURI {
+    NSString *uri = @"video title";
+
+    MUXSDKBandwidthMetricData *metricData = [MUXSDKBandwidthMetricData new];
+    [metricData updateURLPropertiesAndRequestTypeWithRequestURI:uri];
+
+    XCTAssertEqualObjects(metricData.requestUrl, uri);
+    XCTAssertEqualObjects(metricData.requestHostName, uri);
+    XCTAssertNil(metricData.requestType);
+}
+
+- (void)testNoHostname {
+    NSString *uri = @"/playlist.m3u8";
+
+    MUXSDKBandwidthMetricData *metricData = [MUXSDKBandwidthMetricData new];
+    [metricData updateURLPropertiesAndRequestTypeWithRequestURI:uri];
+
+    XCTAssertEqualObjects(metricData.requestUrl, uri);
+    XCTAssertEqualObjects(metricData.requestHostName, uri);
+    XCTAssertEqualObjects(metricData.requestType, @"manifest");
+}
+
+- (void)testCommonExtensions API_AVAILABLE(ios(14), tvos(14)) {
+    [@{
+        @"manifest": @[
+            @"m3u8",
+            @"m3u",
+        ],
+        @"media": @[
+            @"mp4",
+            @"ts",
+            @"mov",
+        ],
+        @"audio": @[
+            @"aac",
+            @"ac3",
+            @"m4a",
+            @"mp3",
+        ],
+    } enumerateKeysAndObjectsUsingBlock:^(NSString *requestType, NSArray<NSString *> *commonExtensions, BOOL * _Nonnull stop) {
+        for (NSString *extension in commonExtensions) {
+            NSString *uri = [@"https://example.com/file." stringByAppendingString:extension];
+
+            MUXSDKBandwidthMetricData *metricData = [MUXSDKBandwidthMetricData new];
+            [metricData updateURLPropertiesAndRequestTypeWithRequestURI:uri];
+
+            XCTAssertEqualObjects(metricData.requestUrl, uri);
+            XCTAssertEqualObjects(metricData.requestHostName, @"example.com");
+            XCTAssertEqualObjects(metricData.requestType, requestType);
+        }
+    }];
+}
+
+@end


### PR DESCRIPTION
The previous implementation could cause a crash when `pathExtension` was `nil`. I've just reverted the `UTType` stuff since it's not especially valuable in this best-effort fallback helper method.