### PR TITLE
Use Mux assets in tests

### DIFF
--- a/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
@@ -427,7 +427,7 @@ struct IntegrationTests {
         try? await Task.sleep(nanoseconds: UInt64(20 * 1_000_000_000))
         
         // End the view
-        let watchTimeEnd = getLastTimestamp(for: playerName)!.doubleValue
+        let watchTimeEnd = try #require(getLastTimestamp(for: playerName)).doubleValue
         binding.detachAVPlayer()
         
         // Calculate actual watch time

--- a/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
@@ -36,9 +36,9 @@ struct IntegrationTests {
         #expect(containsPlayEvent)
     }
     
-    func assertWaitForNSeconds(n seconds: Double, with player: AVPlayer, for playerName: String) {
+    func assertWaitForNSeconds(n seconds: Double, with player: AVPlayer, for playerName: String) throws {
         NSLog("## Wait approximately \(seconds) seconds")
-        let waitTimeBefore = getLastTimestamp(for: playerName)!.doubleValue
+        let waitTimeBefore = try #require(getLastTimestamp(for: playerName)).doubleValue
         let beforeTimePlayer = player.currentTime().seconds
         
         var currentTimePlayer = player.currentTime().seconds
@@ -54,7 +54,7 @@ struct IntegrationTests {
             }
         }
         
-        let waitTimeAfter = getLastTimestamp(for: playerName)!.doubleValue
+        let waitTimeAfter = try #require(getLastTimestamp(for: playerName)).doubleValue
         let waitTimeDiff = waitTimeAfter - waitTimeBefore
         let lowerBound = (seconds * 1000) - msTolerance
         let upperBound = (seconds * 1000) + msTolerance
@@ -63,15 +63,15 @@ struct IntegrationTests {
         #expect(waitTimeDiff >= lowerBound && waitTimeDiff <= upperBound, "Waited \(waitTimeDiff)ms, expected between \(lowerBound)ms and \(upperBound)ms")
     }
     
-    func assertPauseForNSeconds(n seconds: Double, with player: AVPlayer, for playerName: String) async {
+    func assertPauseForNSeconds(n seconds: Double, with player: AVPlayer, for playerName: String) async throws {
         NSLog("## Pause the content for \(seconds) seconds")
-        let waitTimeBefore = getLastTimestamp(for: playerName)!.doubleValue
+        let waitTimeBefore = try #require(getLastTimestamp(for: playerName)).doubleValue
         await MainActor.run {
             player.pause()
         }
         try? await Task.sleep(nanoseconds: UInt64(dispatchDelay * 1_000_000_000))
-        let waitTimeAfter = getLastTimestamp(for: playerName)!.doubleValue
-        
+        let waitTimeAfter = try #require(getLastTimestamp(for: playerName)).doubleValue
+
         let waitTimeDiff = waitTimeAfter - waitTimeBefore
         // Expect that time difference is approximately 0 seconds
         #expect(waitTimeDiff >= 0 && waitTimeDiff < msTolerance)
@@ -175,29 +175,29 @@ struct IntegrationTests {
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+
         // Pause the content for 5 seconds
-        await assertPauseForNSeconds(n: 5.0, with: avPlayer, for: playerName)
-        
+        try await assertPauseForNSeconds(n: 5.0, with: avPlayer, for: playerName)
+
         // Unpause the content
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+
         // Seek backwards in the video 5 seconds
         assertSeekNSeconds(n: -5.0, with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+
         // Seek forwards in the video 10 seconds
         assertSeekNSeconds(n: 10.0, with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+
         // Exit the player by going back to the menu
         binding.detachAVPlayer()
     }
@@ -218,29 +218,29 @@ struct IntegrationTests {
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait approximately 10 seconds
-        assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+
         // Pause the content for 5 seconds
-        await assertPauseForNSeconds(n: 5.0, with: avPlayer, for: playerName)
-        
+        try await assertPauseForNSeconds(n: 5.0, with: avPlayer, for: playerName)
+
         // Unpause the content
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+
         // Seek backwards in the video 5 seconds
         assertSeekNSeconds(n: -5.0, with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+
         // Seek forwards in the video 5 seconds
         assertSeekNSeconds(n: 5.0, with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+
         // Exit the player by going back to the menu
         binding.detachAVPlayer()
     }
@@ -295,8 +295,8 @@ struct IntegrationTests {
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
+
         let vodDurationSeconds = await MainActor.run { () -> Double in
             let duration = avPlayer.currentItem?.asset.duration
             return CMTimeGetSeconds(duration!)
@@ -329,8 +329,8 @@ struct IntegrationTests {
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait 5 seconds
-        assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
+
         // Select a different content title
         try assertChangeVideoSource(from: FIRST_VIDEO_URL, to: SECOND_VIDEO_URL, with: avPlayer, for: playerName)
         
@@ -338,8 +338,8 @@ struct IntegrationTests {
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait 5 seconds
-        assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
-        
+        try assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
+
         binding.detachAVPlayer()
     }
   

--- a/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
+++ b/Fixtures/IntegrationTests/IntegrationTests/IntegrationTests.swift
@@ -1,6 +1,9 @@
 import Testing
 @testable import MUXSDKStats
 
+let vodURL = URL(string: "https://stream.mux.com/a4nOgmxGWg6gULfcBbAa00gXyfcwPnAFldF8RdsNyk8M.m3u8")!
+let liveURL = URL(string: "https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8")!
+
 @Suite
 struct IntegrationTests {
     let dispatchDelay = 3.0
@@ -167,36 +170,35 @@ struct IntegrationTests {
         }
         
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
-        let VOD_URL = "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
-        let avPlayer = AVPlayer(url: URL(string: VOD_URL)!)
+        let avPlayer = AVPlayer(url: vodURL)
         binding.attach(avPlayer)
         
         // Start playing VoD content
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+        try assertWaitForNSeconds(n : 3.0, with: avPlayer, for: playerName)
 
         // Pause the content for 5 seconds
-        try await assertPauseForNSeconds(n: 5.0, with: avPlayer, for: playerName)
+        try await assertPauseForNSeconds(n: 3.0, with: avPlayer, for: playerName)
 
         // Unpause the content
         await assertStartPlaying(with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+        try assertWaitForNSeconds(n : 3.0, with: avPlayer, for: playerName)
 
         // Seek backwards in the video 5 seconds
         assertSeekNSeconds(n: -5.0, with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+        try assertWaitForNSeconds(n : 2.0, with: avPlayer, for: playerName)
 
         // Seek forwards in the video 10 seconds
-        assertSeekNSeconds(n: 10.0, with: avPlayer, for: playerName)
+        assertSeekNSeconds(n: 4.0, with: avPlayer, for: playerName)
         
         // Wait approximately 5 seconds
-        try assertWaitForNSeconds(n : 5.0, with: avPlayer, for: playerName)
+        try assertWaitForNSeconds(n : 2.0, with: avPlayer, for: playerName)
 
         // Exit the player by going back to the menu
         binding.detachAVPlayer()
@@ -250,8 +252,7 @@ struct IntegrationTests {
         MUXSDKCore.swizzleDispatchEvents()
         MUXSDKCore.resetCapturedEvents(forPlayer: playerName)
         
-        let LIVE_URL = "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
-        let avPlayer = AVPlayer(url: URL(string: LIVE_URL)!)
+        let avPlayer = AVPlayer(url: liveURL)
         let playerViewController = await MainActor.run {
             AVPlayerViewController()
         }
@@ -287,8 +288,7 @@ struct IntegrationTests {
         }
         
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
-        let VOD_URL = "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
-        let avPlayer = AVPlayer(url: URL(string: VOD_URL)!)
+        let avPlayer = AVPlayer(url: vodURL)
         binding.attach(avPlayer)
         
         // Start playing content
@@ -319,10 +319,7 @@ struct IntegrationTests {
         
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
         
-        let SECOND_VIDEO_URL = URL(string: "https://stream.mux.com/v69RSHhFelSm4701snP22dYz2jICy4E4FUyk02rW4gxRM.m3u8")!
-        
-        let FIRST_VIDEO_URL = URL(string: "https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8")!
-        let avPlayer = AVPlayer(url: FIRST_VIDEO_URL)
+        let avPlayer = AVPlayer(url: vodURL)
         binding.attach(avPlayer)
         
         // Begin playback of first content title
@@ -332,7 +329,7 @@ struct IntegrationTests {
         try assertWaitForNSeconds(n: 5.0, with: avPlayer, for: playerName)
 
         // Select a different content title
-        try assertChangeVideoSource(from: FIRST_VIDEO_URL, to: SECOND_VIDEO_URL, with: avPlayer, for: playerName)
+        try assertChangeVideoSource(from: vodURL, to: liveURL, with: avPlayer, for: playerName)
         
         // Start playing the new content
         await assertStartPlaying(with: avPlayer, for: playerName)
@@ -353,8 +350,8 @@ struct IntegrationTests {
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
         
         // Use an invalid URL
-        let INVALID_URL = URL(string:"https://bitdash-a.akamaihd.net/content/nonexistent/invalid.m3u8")!
-        let avPlayer = AVPlayer(url: INVALID_URL)
+        let notFoundURL = URL(string: "https://stream.mux.com/invalid.m3u8")!
+        let avPlayer = AVPlayer(url: notFoundURL)
         binding.attach(avPlayer)
         
         // Try to play the invalid content which should trigger a fatal error
@@ -412,8 +409,7 @@ struct IntegrationTests {
         }
         
         let binding = MUXSDKPlayerBinding(playerName: playerName, softwareName: "TestSoftwareName", softwareVersion: "TestSoftwareVersion")
-        let VOD_URL = URL(string:"https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8")!
-        let avPlayer = AVPlayer(url: VOD_URL)
+        let avPlayer = AVPlayer(url: vodURL)
         binding.attach(avPlayer)
         
         // Start playing content

--- a/Tests/MUXSDKStatsTests/MUXSDKStatsTests.m
+++ b/Tests/MUXSDKStatsTests/MUXSDKStatsTests.m
@@ -16,6 +16,8 @@
 
 #define MUXUniquePlayerName() [NSString stringWithFormat:@"Player for %s (%@)", __PRETTY_FUNCTION__, NSUUID.UUID.UUIDString]
 
+NSString *const MUXTestVODURLString = @"https://stream.mux.com/a4nOgmxGWg6gULfcBbAa00gXyfcwPnAFldF8RdsNyk8M.m3u8";
+
 @interface MuxMockAVPlayerViewController : AVPlayerViewController
 @end
 
@@ -254,7 +256,7 @@ static NSString *Z = @"Z";
     newCustomerData.customerVideoData = newCustomerVideoData;
     // It is required to call videoChangeForPlayer: immediately before telling the player which new source to play.
     [MUXSDKStats videoChangeForPlayer:playName withCustomerData:newCustomerData];
-    NSURL* videoURL = [NSURL URLWithString:@"https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"];
+    NSURL* videoURL = [NSURL URLWithString:MUXTestVODURLString];
     AVPlayerItem *item = [AVPlayerItem playerItemWithURL:videoURL];
     [controller.player replaceCurrentItemWithPlayerItem:item];
 
@@ -395,7 +397,7 @@ static NSString *Z = @"Z";
     customerData.customerVideoData = newCustomerVideoData;
     // It is required to call videoChangeForPlayer: immediately before telling the player which new source to play.
     [MUXSDKStats videoChangeForPlayer:playName withCustomerData:customerData];
-    NSURL* videoURL = [NSURL URLWithString:@"https://bitdash-a.akamaihd.net/content/sintel/hls/playlist.m3u8"];
+    NSURL* videoURL = [NSURL URLWithString:MUXTestVODURLString];
     AVPlayerItem *item = [AVPlayerItem playerItemWithURL:videoURL];
     [controller.player replaceCurrentItemWithPlayerItem:item];
 


### PR DESCRIPTION
Uses well-known Mux assets for integration tests, modifying tests for timing to work with the new assets.

Additionally integration tests were themselves crashing, leading to useless results. This PR also changes the force-unwrapping of optionals to throwing `#require`s, but with no other attempt to change behavior.