### PR TITLE
Use full Swift 6 mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -48,13 +48,7 @@ let package = Package(
                     description: "Generates a podspec for the SDK"))),
     ],
     swiftLanguageModes: [
-        .v5,
+        .v6,
     ]
 )
 
-for target in package.targets where target.type != .plugin {
-    target.swiftSettings = (target.swiftSettings ?? []) + [
-        .enableUpcomingFeature("StrictConcurrency"),
-        .enableUpcomingFeature("InternalImportsByDefault"),
-    ]
-}

--- a/Tests/MUXSDKStatsInternalTests/MuxTimeValueConvertibleTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/MuxTimeValueConvertibleTests.swift
@@ -62,6 +62,7 @@ struct MuxTimeValueConvertibleTests {
     ]
 
     // Set wrapping required due to Xcode 16 bug "Fatal error: Internal inconsistency: No test reporter for test case argumentIDs"
+    // https://forums.swift.org/t/fatal-error-internal-inconsistency-no-test-reporter-for-test-case-argumentids/75666/8
     @Test(arguments: Set(validTimeIntervals))
     func validTimeIntervalBehavior(timeInterval: TimeInterval) throws {
         let muxTimeValue = try #require(timeInterval.muxTimeValue)
@@ -112,7 +113,7 @@ struct MuxTimeValueConvertibleTests {
     ]
 
     static var validCMTimes: [CMTime] {
-        [
+        let allTimes = [
             CMTime.zero,
         ]
         +
@@ -121,10 +122,18 @@ struct MuxTimeValueConvertibleTests {
                 CMTime(seconds: timeInterval, preferredTimescale: $0)
             }
         }
+
+        // Non-unique arguments lead to Xcode 16 bug "Fatal error: Internal inconsistency: No test reporter for test case argumentIDs"
+        // But also the above produces lots of duplicates.
+        struct HashableCMTimeWrapper: Hashable {
+            let timeValue: CMTime
+        }
+
+        return Set(allTimes.map(HashableCMTimeWrapper.init))
+            .map(\.timeValue)
     }
 
-    // Set wrapping required due to Xcode 16 bug "Fatal error: Internal inconsistency: No test reporter for test case argumentIDs"
-    @Test(arguments: Set(validCMTimes))
+    @Test(arguments: validCMTimes)
     func validCMTimeBehavior(cmTime: CMTime) throws {
         let muxTimeValue = try #require(cmTime.muxTimeValue)
 

--- a/scripts/MUXSDKStatsFramework.xcodeproj/project.pbxproj
+++ b/scripts/MUXSDKStatsFramework.xcodeproj/project.pbxproj
@@ -225,6 +225,7 @@
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -285,6 +286,7 @@
 				SUPPORTED_PLATFORMS = "xrsimulator xros watchsimulator watchos macosx iphonesimulator iphoneos driverkit appletvsimulator appletvos";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -330,7 +332,6 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_MODULE = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,6,7";
 				TVOS_DEPLOYMENT_TARGET = 12.0;
 				VALIDATE_PRODUCT = YES;
@@ -378,7 +379,6 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_INSTALL_MODULE = YES;
 				SWIFT_INSTALL_OBJC_HEADER = NO;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3,6,7";
 				TVOS_DEPLOYMENT_TARGET = 12.0;
 				VALIDATE_PRODUCT = YES;


### PR DESCRIPTION
The internal Swift target was already compliant, there were just some tests that needed updating. They've been updated with comments.