### PR TITLE
requestMediaStartTime should not be set via AVMetricsEvent

### DIFF
--- a/Sources/MUXSDKStatsInternal/MuxCore/MUXSDKBandwidthMetricData+AVMetrics.swift
+++ b/Sources/MUXSDKStatsInternal/MuxCore/MUXSDKBandwidthMetricData+AVMetrics.swift
@@ -3,14 +3,8 @@ import MuxCore
 
 @available(iOS 18, tvOS 18, visionOS 2, *)
 extension MUXSDKBandwidthMetricData {
-    convenience init(metricEvent event: AVMetricEvent) {
-        self.init()
-
-        requestMediaStartTime = event.mediaTime.muxTimeValue
-    }
-
     convenience init(mediaResourceRequestEvent event: AVMetricMediaResourceRequestEvent) {
-        self.init(metricEvent: event)
+        self.init()
 
         requestUrl = event.url?.absoluteString
         requestHostName = event.url?.host()


### PR DESCRIPTION
`requestMediaStartTime` represents the starting point of the downloaded media, while `AVMetricEvent.mediaTime` represents the point on the media timeline when the event occurred.