### PR TITLE
Use type information on bindings

### DIFF
--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -1477,13 +1477,13 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
 @end
 
 
-@interface MUXSDKAVPlayerBinding ()
+@interface MUXSDKFixedPlayerSizeBinding ()
 
 @property (nonatomic, readonly) CGSize fixedPlayerSize;
 
 @end
 
-@implementation MUXSDKAVPlayerBinding
+@implementation MUXSDKFixedPlayerSizeBinding
 
 - (nonnull id)initWithPlayerName:(nonnull NSString *)playerName
                     softwareName:(nullable NSString *)softwareName
@@ -1525,5 +1525,10 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
         _fixedPlayerSize.height
     )];
 }
+
+@end
+
+// Stub implementation
+@implementation MUXSDKAVPlayerBinding
 
 @end

--- a/Sources/MUXSDKStats/MUXSDKPlayerBindingManager.h
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBindingManager.h
@@ -22,7 +22,7 @@
 @property (nonatomic, weak) id<MUXSDKCustomerVideoDataStoring> _Nullable customerVideoDataStore;
 @property (nonatomic, weak) id<MUXSDKCustomerViewDataStoring> _Nullable customerViewDataStore;
 @property (nonatomic, weak) id<MUXSDKCustomerCustomDataStoring> _Nullable customerCustomDataStore;
-@property (nonatomic, weak) NSDictionary * _Nullable viewControllers;
+@property (nonatomic, weak) NSDictionary<NSString *, __kindof MUXSDKPlayerBinding *> *bindingsByPlayerName;
 
 - (void) newViewForPlayer:(NSString *_Nonnull) name;
 - (void) onPlayerDestroyed:(NSString *_Nonnull) name;

--- a/Sources/MUXSDKStats/MUXSDKPlayerBindingManager.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBindingManager.m
@@ -38,7 +38,7 @@
 
 - (void) newViewForPlayer:(NSString *_Nonnull) name {
     if (![self hasInitializedPlayerBinding: name]) {
-        MUXSDKPlayerBinding *binding = [self.viewControllers valueForKey:name];
+        MUXSDKPlayerBinding *binding = self.bindingsByPlayerName[name];
            if (binding != nil) {
                MUXSDKCustomerPlayerData *playerData = [self.customerPlayerDataStore playerDataForPlayerName:name];
                MUXSDKCustomerVideoData *videoData = [self.customerVideoDataStore videoDataForPlayerName:name];
@@ -82,7 +82,7 @@
 }
 
 - (void) videoChangedForPlayer:(NSString *_Nonnull) name {
-    MUXSDKPlayerBinding *binding = [self.viewControllers valueForKey:name];
+    MUXSDKPlayerBinding *binding = self.bindingsByPlayerName[name];
     if (binding != nil) {
         [binding dispatchViewInit];
         MUXSDKCustomerPlayerData *playerData = [self.customerPlayerDataStore playerDataForPlayerName:name];

--- a/Sources/MUXSDKStats/include/MUXSDKStats/MUXSDKPlayerBinding.h
+++ b/Sources/MUXSDKStats/include/MUXSDKStats/MUXSDKPlayerBinding.h
@@ -227,7 +227,7 @@ API_UNAVAILABLE(visionos)
 
 @end
 
-@interface MUXSDKAVPlayerBinding : MUXSDKPlayerBinding
+@interface MUXSDKFixedPlayerSizeBinding : MUXSDKPlayerBinding
 
 
 /// Initializes a binding that listens for and dispatches player events
@@ -251,4 +251,9 @@ API_UNAVAILABLE(visionos)
                  softwareVersion:(nullable NSString *)softwareVersion
                  fixedPlayerSize:(CGSize)fixedPlayerSize;
 
+@end
+
+// Support a previous naming of this class
+DEPRECATED_MSG_ATTRIBUTE("Please migrate to MUXSDKFixedPlayerSizeBinding")
+@interface MUXSDKAVPlayerBinding: MUXSDKFixedPlayerSizeBinding
 @end

--- a/Tests/MUXSDKStatsTests/MUXSDKPlayerBindingTests.m
+++ b/Tests/MUXSDKStatsTests/MUXSDKPlayerBindingTests.m
@@ -38,7 +38,7 @@
     
     sut.customerPlayerDataStore = playerDataStore;
     sut.customerVideoDataStore = videoDataStore;
-    sut.viewControllers = vcs;
+    sut.bindingsByPlayerName = vcs;
 
     NSURL *url = [[NSURL alloc] initWithString:@"https://foo.mp4"];
     AVPlayer *player = [AVPlayer playerWithURL:url];
@@ -76,7 +76,7 @@
 
     sut.customerPlayerDataStore = playerDataStore;
     sut.customerVideoDataStore = videoDataStore;
-    sut.viewControllers = vcs;
+    sut.bindingsByPlayerName = vcs;
 
     // Set up player
     NSURL *url = [[NSURL alloc] initWithString:@"https://foo.mp4"];


### PR DESCRIPTION
Uses the actual binding object type (polymorphism instead of stringly-typed indirection). Previously there was a dictionary of strings that held the binding type and another dictionary of bindings. Confusingly, the dictionary of strings was named `_bindings` and this spread to various local variables. Also renamed the fixed player size binding class to a less deceptive name, as previously it implied that it was the binding class for `AVPlayer`.

This cleanup was done as a clean base to implement player property observing.