### PR TITLE
Automatically follow the player property on AVPlayerViewController/AVPlayerLayer

### DIFF
--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -830,7 +830,6 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
 
 - (BOOL)hasPlayer {
     if (!_player) {
-        NSLog(@"MUXSDK-ERROR - Mux failed to find the AVPlayer for player name: %@", _name);
         return NO;
     }
     return YES;
@@ -1365,7 +1364,7 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
 
 @interface MUXSDKAVPlayerViewControllerBinding ()
 
-@property (nonatomic, readonly) AVPlayerViewController *viewController;
+@property (nonatomic, nullable) MUXSDKStrongKVOPlayerVCBinding *kvoBinding;
 
 @end
 
@@ -1378,11 +1377,48 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
                 playerViewController:view];
 }
 
+- (void)setAutomaticallyAttachesPlayerProperty:(BOOL)automaticallyAttachesPlayerProperty {
+    _automaticallyAttachesPlayerProperty = automaticallyAttachesPlayerProperty;
+    if (automaticallyAttachesPlayerProperty) {
+        AVPlayer *player = self.kvoBinding.playerViewController.player;
+        if (player) {
+            [self attachAVPlayer:player];
+        }
+    }
+}
+
+- (AVPlayerViewController *)viewController {
+    return self.kvoBinding.playerViewController;
+}
+
+- (void)setViewController:(AVPlayerViewController *)viewController {
+    if (viewController) {
+        __weak typeof(self) weakSelf = self;
+        self.kvoBinding = [[MUXSDKStrongKVOPlayerVCBinding alloc] initWithPlayerViewController:viewController onPlayerChange:^(AVPlayer *_Nullable player) {
+            [weakSelf playerPropertyDidChange:player];
+        }];
+    } else {
+        self.kvoBinding = nil;
+        [self playerPropertyDidChange:nil];
+    }
+}
+
+- (void)playerPropertyDidChange:(nullable AVPlayer *)newValue {
+    if (!self.automaticallyAttachesPlayerProperty) {
+        return;
+    }
+    if (newValue) {
+        [self attachAVPlayer:newValue];
+    } else {
+        [self detachAVPlayer];
+    }
+}
+
 - (nullable NSValue *)getViewBoundsValue {
     if (![NSThread isMainThread]) {
         return nil;
     }
-    UIView *view = _viewController.viewIfLoaded;
+    UIView *view = self.viewController.viewIfLoaded;
     if (view == nil) {
         return nil;
     }
@@ -1407,7 +1443,7 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
                         softwareName:softwareName
                      softwareVersion:softwareVersion];
     if (self) {
-        _viewController = playerViewController;
+        self.viewController = playerViewController;
     }
     return self;
 }
@@ -1417,7 +1453,7 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
 
 @interface MUXSDKAVPlayerLayerBinding ()
 
-@property (nonatomic, readonly) AVPlayerLayer *view;
+@property (nonatomic, nullable) MUXSDKStrongKVOPlayerLayerBinding *kvoBinding;
 
 @end
 
@@ -1449,13 +1485,50 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
                         softwareName:softwareName
                      softwareVersion:softwareVersion];
     if (self) {
-        _view = playerLayer;
+        self.playerLayer = playerLayer;
     }
     return self;
 }
 
+- (void)setAutomaticallyAttachesPlayerProperty:(BOOL)automaticallyAttachesPlayerProperty {
+    _automaticallyAttachesPlayerProperty = automaticallyAttachesPlayerProperty;
+    if (automaticallyAttachesPlayerProperty) {
+        AVPlayer *player = self.kvoBinding.playerLayer.player;
+        if (player) {
+            [self attachAVPlayer:player];
+        }
+    }
+}
+
+- (AVPlayerLayer *)playerLayer {
+    return self.kvoBinding.playerLayer;
+}
+
+- (void)setPlayerLayer:(AVPlayerLayer *)playerLayer {
+    if (playerLayer) {
+        __weak typeof(self) weakSelf = self;
+        self.kvoBinding = [[MUXSDKStrongKVOPlayerLayerBinding alloc] initWithPlayerLayer:playerLayer onPlayerChange:^(AVPlayer *_Nullable player) {
+            [weakSelf playerPropertyDidChange:player];
+        }];
+    } else {
+        self.kvoBinding = nil;
+        [self playerPropertyDidChange:nil];
+    }
+}
+
+- (void)playerPropertyDidChange:(nullable AVPlayer *)newValue {
+    if (!self.automaticallyAttachesPlayerProperty) {
+        return;
+    }
+    if (newValue) {
+        [self attachAVPlayer:newValue];
+    } else {
+        [self detachAVPlayer];
+    }
+}
+
 - (nullable NSValue *)getViewBoundsValue {
-    return [NSValue valueWithCGRect:_view.bounds];
+    return @(self.playerLayer.bounds);
 }
 
 @end

--- a/Sources/MUXSDKStats/include/MUXSDKStats/MUXSDKPlayerBinding.h
+++ b/Sources/MUXSDKStats/include/MUXSDKStats/MUXSDKPlayerBinding.h
@@ -183,6 +183,12 @@ typedef NS_ENUM(NSUInteger, MUXSDKViewOrientation) {
                  softwareVersion:(nullable NSString *)softwareVersion
             playerViewController:(nonnull AVPlayerViewController *)playerViewController;
 
+// FIXME: move to private header
+@property (nonatomic, nullable) AVPlayerViewController *viewController;
+
+// TODO: document that this is enabled by default by `MUXSDKStats`
+@property (nonatomic) BOOL automaticallyAttachesPlayerProperty;
+
 @end
 
 API_UNAVAILABLE(visionos) 
@@ -224,6 +230,12 @@ API_UNAVAILABLE(visionos)
                     softwareName:(nullable NSString *)softwareName
                  softwareVersion:(nullable NSString *)softwareVersion
                      playerLayer:(nonnull AVPlayerLayer *)playerLayer;
+
+// FIXME: move to private header
+@property (nonatomic, nullable) AVPlayerLayer *playerLayer;
+
+// TODO: document that this is enabled by default by `MUXSDKStats`
+@property (nonatomic) BOOL automaticallyAttachesPlayerProperty;
 
 @end
 

--- a/Sources/MUXSDKStats/include/MUXSDKStats/MUXSDKStats.h
+++ b/Sources/MUXSDKStats/include/MUXSDKStats/MUXSDKStats.h
@@ -205,7 +205,7 @@ FOUNDATION_EXPORT
  @param       fixedPlayerSize A fixed size of your player that will not change, inclusive of any letter boxed or pillar boxed areas. If monitoring audio only media, pass in CGSizeMake(0.0, 0.0)
  @discussion  Use this method to change which AVPlayer a Mux player monitor is watching. The player monitor must previously have been created via a monitorAVPlayer call.
  */
-+ (void)updateAVPlayer:(nonnull AVPlayer *)player
++ (void)updateAVPlayer:(nullable AVPlayer *)player
         withPlayerName:(nonnull NSString *)name
        fixedPlayerSize:(CGSize)fixedPlayerSize;
 

--- a/Sources/MUXSDKStatsInternal/Utilities/StrongKVOPlayerBinding.swift
+++ b/Sources/MUXSDKStatsInternal/Utilities/StrongKVOPlayerBinding.swift
@@ -2,28 +2,54 @@ import Foundation
 import AVKit
 
 @objc(MUXSDKStrongKVOPlayerVCBinding)
-public final class StrongKVOPlayerVCBinding: NSObject {
-    private var observation: NSKeyValueObservation?
-    @objc private(set) public var playerViewController: AVPlayerViewController?
-
+public final class StrongKVOPlayerVCBinding: NSObject, Sendable {
     @MainActor
-    @objc public init(playerViewController: AVPlayerViewController, onPlayerChange: @Sendable @escaping (AVPlayer?) -> Void) {
-        observation = playerViewController.observe(\.player, options: [.initial, .new]) { _, change in
-            onPlayerChange(change.newValue!)
-        }
+    private var observation: NSKeyValueObservation?
+
+    @objc public let playerViewController: AVPlayerViewController
+
+    @objc public init(playerViewController: AVPlayerViewController,
+                      onPlayerChange: @Sendable @escaping (AVPlayer?) -> Void) {
         self.playerViewController = playerViewController
+        super.init()
+
+        let startObserving = { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            self.observation = playerViewController.observe(\.player, options: [.initial, .new]) { _, change in
+                onPlayerChange(change.newValue!)
+            }
+        }
+
+        guard #available(iOS 13, tvOS 13, *) else {
+            DispatchQueue.main.async(execute: startObserving)
+            return
+        }
+
+        if DispatchQueue.isMainQueue {
+            MainActor.assumeIsolated {
+                startObserving()
+            }
+        } else {
+            Task { @MainActor in
+                startObserving()
+            }
+        }
     }
 }
 
 @objc(MUXSDKStrongKVOPlayerLayerBinding)
 public final class StrongKVOPlayerLayerBinding: NSObject {
-    private var observation: NSKeyValueObservation?
-    @objc private(set) public var playerLayer: AVPlayerLayer?
+    private let observation: NSKeyValueObservation
 
-    @objc public init(playerLayer: AVPlayerLayer, onPlayerChange: @Sendable @escaping (AVPlayer?) -> Void) {
+    @objc public let playerLayer: AVPlayerLayer
+
+    @objc public init(playerLayer: AVPlayerLayer,
+                      onPlayerChange: @Sendable @escaping (AVPlayer?) -> Void) {
+        self.playerLayer = playerLayer
         observation = playerLayer.observe(\.player, options: [.initial, .new]) { _, change in
             onPlayerChange(change.newValue!)
         }
-        self.playerLayer = playerLayer
     }
 }

--- a/Sources/MUXSDKStatsInternal/Utilities/StrongKVOPlayerBinding.swift
+++ b/Sources/MUXSDKStatsInternal/Utilities/StrongKVOPlayerBinding.swift
@@ -1,0 +1,29 @@
+import Foundation
+import AVKit
+
+@objc(MUXSDKStrongKVOPlayerVCBinding)
+public final class StrongKVOPlayerVCBinding: NSObject {
+    private var observation: NSKeyValueObservation?
+    @objc private(set) public var playerViewController: AVPlayerViewController?
+
+    @MainActor
+    @objc public init(playerViewController: AVPlayerViewController, onPlayerChange: @Sendable @escaping (AVPlayer?) -> Void) {
+        observation = playerViewController.observe(\.player, options: [.initial, .new]) { _, change in
+            onPlayerChange(change.newValue!)
+        }
+        self.playerViewController = playerViewController
+    }
+}
+
+@objc(MUXSDKStrongKVOPlayerLayerBinding)
+public final class StrongKVOPlayerLayerBinding: NSObject {
+    private var observation: NSKeyValueObservation?
+    @objc private(set) public var playerLayer: AVPlayerLayer?
+
+    @objc public init(playerLayer: AVPlayerLayer, onPlayerChange: @Sendable @escaping (AVPlayer?) -> Void) {
+        observation = playerLayer.observe(\.player, options: [.initial, .new]) { _, change in
+            onPlayerChange(change.newValue!)
+        }
+        self.playerLayer = playerLayer
+    }
+}


### PR DESCRIPTION
Automatically observes changes to [`AVPlayerViewController.player`](https://developer.apple.com/documentation/avkit/avplayerviewcontroller/player) and [`AVPlayerLayer.player`](https://developer.apple.com/documentation/avfoundation/avplayerlayer/player) to set up/tear down monitoring.

Previously most of the SDK's monitoring setup/update methods would fail and do nothing if the `player` property of a view controller or layer was `nil`.

Implemented using Swift's Key-Value Observing helpers for safety and convenience.

Also fixes the `updateAVPlayerViewController:...` and `updateAVPlayerLayer:` methods. Previously they did not actually update the view controller or layer, just checked the player associated with those objects. The original object was still retained by the binding.