### PR TITLE
Avoid duplicate renditionchange events when not using AVMetrics

### DIFF
--- a/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
@@ -50,7 +50,10 @@ extension AVPlayerItem {
                 }
                 return videoAssetTrack
             }
-            .removeDuplicates { $0?.trackID == $1?.trackID }
+        // AVPlayerItemTracks and AVAssetTracks are replaced for various reasons during
+        // playback, during seeking for example. While the following will unique these
+        // objects, a new object here may still refer to the same rendition:
+            .removeDuplicates()
             .flatMap { videoAssetTrack in
                 // Boost priority as this kicks off a chain of timing-sensitive operations
                 return Future(priority: .userInitiated) {
@@ -60,6 +63,15 @@ extension AVPlayerItem {
                     }
                     return await (timing, MUXSDKVideoData.makeWithRenditionInfo(track: videoAssetTrack, on: self))
                 }
+            }
+        // Determine uniqueness (and therefore rendition changes) based on fully populated
+        // video data:
+            .removeDuplicates { timedInfoA, timedInfoB in
+                let (_, videoDataA) = timedInfoA
+                let (_, videoDataB) = timedInfoB
+                let queryDictA = videoDataA.toQuery() as NSDictionary
+                let queryDictB = videoDataB.toQuery() as NSDictionary
+                return queryDictA == queryDictB
             }
     }
 


### PR DESCRIPTION
When not using AVMetrics (iOS/tvOS devices <18, all simulators) duplicate `renditionchange` events can be generated. This PR compares the fully populated video data to filter out these duplicates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the deduplication criteria for rendition change analytics and could suppress or merge events if `videoData` fields are missing or unstable across updates.
> 
> **Overview**
> Prevents duplicate `renditionchange` events when AVMetrics isn’t available by changing `timedRenditionInfoPublisher()` to **stop deduping on `AVAssetTrack.trackID`** and instead dedupe after `MUXSDKVideoData` is built.
> 
> Rendition uniqueness is now determined by comparing the full `videoData.toQuery()` payload, reducing false positives from track/asset objects being replaced during seek/playback.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe1bbebad84a6b1097b99664394c654ab8eb3f0c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->