### PR TITLE
NAT-412: Add AVPlayer Audio Track Change Events

### DIFF
--- a/Examples/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/MUXSDKStatsExampleSPM/MUXSDKStatsExampleSPM.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "ced72dd94331be52d71e12efffbd77713ab3fcafa191a8c9f8d9b0e5dd4db889",
+  "originHash" : "a6ef3c94d4539aa8c540f965ea2a3dd4068cfc51108f27c487f5bf4d55715bc9",
   "pins" : [
     {
       "identity" : "mux-stats-sdk-objc",
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:muxinc/mux-stats-sdk-objc.git",
       "state" : {
-        "branch" : "feature/nat-333-text-track-changes",
-        "revision" : "e021747caf86eab9928b251950979b1f275dc7b0"
+        "branch" : "feature/nat-416-audio-track-changes",
+        "revision" : "963d1b1a5de38a9d2ce47f37429fcf713e8648b9"
       }
     }
   ],

--- a/Fixtures/IntegrationTests/IntegrationTests.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Fixtures/IntegrationTests/IntegrationTests.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "af406a2480b3962af06c67874e3cf896b95675ebe6fd61903b521acfa926108f",
+  "originHash" : "a4da08a770d5023080a7387443169b55ad24136531b9e43ff69735ef985c6aee",
   "pins" : [
     {
       "identity" : "mux-stats-sdk-objc",
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:muxinc/mux-stats-sdk-objc.git",
       "state" : {
-        "branch" : "feature/nat-333-text-track-changes",
-        "revision" : "e021747caf86eab9928b251950979b1f275dc7b0"
+        "branch" : "feature/nat-416-audio-track-changes",
+        "revision" : "963d1b1a5de38a9d2ce47f37429fcf713e8648b9"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "af406a2480b3962af06c67874e3cf896b95675ebe6fd61903b521acfa926108f",
+  "originHash" : "a4da08a770d5023080a7387443169b55ad24136531b9e43ff69735ef985c6aee",
   "pins" : [
     {
       "identity" : "mux-stats-sdk-objc",
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:muxinc/mux-stats-sdk-objc.git",
       "state" : {
-        "branch" : "feature/nat-333-text-track-changes",
-        "revision" : "e021747caf86eab9928b251950979b1f275dc7b0"
+        "branch" : "feature/nat-416-audio-track-changes",
+        "revision" : "963d1b1a5de38a9d2ce47f37429fcf713e8648b9"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .package(
             name: "stats-sdk-objc",
             url: "git@github.com:muxinc/mux-stats-sdk-objc.git",
-            branch: "feature/nat-333-text-track-changes"),
+            branch: "feature/nat-416-audio-track-changes"),
     ],
     targets: [
         .target(

--- a/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
@@ -128,6 +128,8 @@ struct AudioTrackChangeEvents {
         }
 
         static func codecString(for formatID: AudioFormatID) -> String? {
+            // Explicit mappings only for common streaming-video audio codecs.
+            // Return nil for anything else rather than guessing.
             switch formatID {
             case kAudioFormatAC3:
                 return "ac-3"

--- a/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
@@ -1,0 +1,309 @@
+import AudioToolbox
+import AVFoundation
+import Combine
+@preconcurrency import MuxCore
+
+@available(iOS 15, tvOS 15, *)
+struct AudioTrackChangeEvents {
+
+    struct AudioTrackInfo: Equatable, Hashable, Sendable {
+        let name: String
+        let language: String?
+        let codec: String?
+        let bitrate: Int?
+        let channels: MUXSDKAudioTrackChannelLayout?
+
+        init(
+            name: String,
+            language: String?,
+            codec: String?,
+            bitrate: Int?,
+            channels: MUXSDKAudioTrackChannelLayout?
+        ) {
+            self.name = name
+            self.language = language
+            self.codec = codec
+            self.bitrate = bitrate
+            self.channels = channels
+        }
+
+        @MainActor
+        init?(_ playerItem: AVPlayerItem) async {
+            guard let mediaSelectionOption = await playerItem.currentMediaSelection.selectedMediaOptionInGroup(for: .audible) else {
+                return nil
+            }
+
+            if let hlsName = await mediaSelectionOption.loadHLSNameAttributeValue() {
+                name = hlsName
+            } else if let title = await mediaSelectionOption.loadTitle() {
+                name = title
+            } else {
+                // This will be in the user's locale, so it is lowest preference.
+                name = mediaSelectionOption.displayName
+            }
+
+            language = mediaSelectionOption.extendedLanguageTag
+
+            let assetTrackInfo: AssetTrackInfo?
+            if let assetTrack = await Self.selectedAudioAssetTrack(on: playerItem, language: language) {
+                assetTrackInfo = await AssetTrackInfo(assetTrack)
+            } else {
+                assetTrackInfo = nil
+            }
+
+            codec = assetTrackInfo?.codec
+            bitrate = assetTrackInfo?.bitrate
+            channels = assetTrackInfo?.channels
+        }
+
+        @MainActor
+        private static func selectedAudioAssetTrack(on playerItem: AVPlayerItem, language: String?) async -> AVAssetTrack? {
+            let enabledAudioTracks = playerItem.tracks.compactMap { (track: AVPlayerItemTrack) -> AVAssetTrack? in
+                guard track.isEnabled,
+                      let assetTrack = track.assetTrack,
+                      assetTrack.mediaType == .audio else {
+                    return nil
+                }
+                return assetTrack
+            }
+
+            switch enabledAudioTracks.count {
+            case 0:
+                return nil
+            case 1:
+                return enabledAudioTracks.first
+            default:
+                guard let language else {
+                    return nil
+                }
+
+                var matchingTracks = [AVAssetTrack]()
+                for assetTrack in enabledAudioTracks {
+                    if assetTrack.extendedLanguageTag == language {
+                        matchingTracks.append(assetTrack)
+                    }
+                }
+
+                return matchingTracks.count == 1 ? matchingTracks.first : nil
+            }
+        }
+    }
+
+    struct AssetTrackInfo: Equatable, Hashable, Sendable {
+        let codec: String?
+        let bitrate: Int?
+        let channels: MUXSDKAudioTrackChannelLayout?
+
+        @MainActor
+        init?(_ assetTrack: AVAssetTrack) async {
+            let formatDescriptions: [CMFormatDescription]
+            let estimatedDataRate: Float
+            do {
+                (formatDescriptions, estimatedDataRate) = try await assetTrack.load(
+                    .formatDescriptions,
+                    .estimatedDataRate)
+            } catch {
+                logger.debug("Failed to load audio track metadata on \(assetTrack): \(error)")
+                return nil
+            }
+
+            let audioFormatDescriptions = formatDescriptions.filter { $0.mediaType == .audio }
+            codec = Self.uniqueValue(audioFormatDescriptions.compactMap(Self.codecString(for:)))
+
+            if estimatedDataRate > 0 {
+                bitrate = Int(estimatedDataRate.rounded())
+            } else {
+                bitrate = nil
+            }
+
+            channels = Self.uniqueValue(audioFormatDescriptions.compactMap(Self.channelLayout(for:)))
+        }
+
+        static func codecString(for formatDescription: CMFormatDescription) -> String? {
+            guard formatDescription.mediaType == .audio else {
+                return nil
+            }
+
+            return codecString(for: formatDescription.mediaSubType.rawValue)
+        }
+
+        static func codecString(for formatID: AudioFormatID) -> String? {
+            switch formatID {
+            case kAudioFormatAC3:
+                return "ac-3"
+            case kAudioFormatEnhancedAC3:
+                return "ec-3"
+            case kAudioFormatMPEG4AAC:
+                return "mp4a.40.2"
+            case kAudioFormatMPEG4AAC_HE:
+                return "mp4a.40.5"
+            case kAudioFormatMPEG4AAC_HE_V2:
+                return "mp4a.40.29"
+            case kAudioFormatMPEGD_USAC:
+                return "mp4a.40.42"
+            case kAudioFormatOpus:
+                return "opus"
+            default:
+                return nil
+            }
+        }
+
+        static func channelLayout(for formatDescription: CMFormatDescription) -> MUXSDKAudioTrackChannelLayout? {
+            guard formatDescription.mediaType == .audio else {
+                return nil
+            }
+
+            let audioFormatDescription = formatDescription as CMAudioFormatDescription
+
+            var channelLayoutSize = 0
+            if let channelLayout = CMAudioFormatDescriptionGetChannelLayout(
+                audioFormatDescription,
+                sizeOut: &channelLayoutSize
+            ) {
+                let layoutTag = channelLayout.pointee.mChannelLayoutTag
+                if isAtmos(layoutTag: layoutTag) {
+                    return .atmos
+                }
+            }
+
+            guard let audioFormat = CMAudioFormatDescriptionGetRichestDecodableFormat(audioFormatDescription)
+                ?? CMAudioFormatDescriptionGetMostCompatibleFormat(audioFormatDescription) else {
+                return nil
+            }
+
+            return channelLayout(
+                channelCount: Int(audioFormat.pointee.mASBD.mChannelsPerFrame),
+                audioChannelLayoutTag: nil)
+        }
+
+        static func channelLayout(
+            channelCount: Int,
+            audioChannelLayoutTag: AudioChannelLayoutTag?
+        ) -> MUXSDKAudioTrackChannelLayout? {
+            if let audioChannelLayoutTag, isAtmos(layoutTag: audioChannelLayoutTag) {
+                return .atmos
+            }
+
+            switch channelCount {
+            case 1:
+                return .mono
+            case 2:
+                return .stereo
+            case 6:
+                return .fivePointOne
+            case 8:
+                return .sevenPointOne
+            case let count where count > 0:
+                return .init("\(count)")
+            default:
+                return nil
+            }
+        }
+
+        private static func isAtmos(layoutTag: AudioChannelLayoutTag) -> Bool {
+            switch layoutTag {
+            case kAudioChannelLayoutTag_Atmos_5_1_2,
+                 kAudioChannelLayoutTag_Atmos_5_1_4,
+                 kAudioChannelLayoutTag_Atmos_7_1_2,
+                 kAudioChannelLayoutTag_Atmos_7_1_4,
+                 kAudioChannelLayoutTag_Atmos_9_1_6:
+                return true
+            default:
+                return false
+            }
+        }
+
+        private static func uniqueValue<T: Hashable>(_ values: [T]) -> T? {
+            let uniqueValues = Set(values)
+            guard uniqueValues.count == 1 else {
+                return nil
+            }
+            return uniqueValues.first
+        }
+    }
+
+    let playerItem: AVPlayerItem
+    let minimumIntervalBetweenEvents: TimeInterval
+
+    init(playerItem: AVPlayerItem, minimumIntervalBetweenEvents: TimeInterval = 0.25) {
+        self.playerItem = playerItem
+        self.minimumIntervalBetweenEvents = minimumIntervalBetweenEvents
+    }
+
+    func allEvents() -> some Publisher<MUXSDKAudioTrackChangeEvent, Never> {
+        playerItem.readyToPlayPublisher
+            .catch { _ in
+                // Ignore status failed error.
+                return Empty<AVPlayerItem, Never>()
+            }
+            .flatMap { playerItem in
+                let captureAudioTrackInfo = {
+                    Future(priority: .userInitiated) { @MainActor in
+                        async let timing = await playerItem.currentTiming()
+                        let trackInfo = await AudioTrackInfo(playerItem)
+
+                        return (
+                            timing: await timing,
+                            trackInfo: trackInfo
+                        )
+                    }
+                }
+
+                let audioTrackChanges = NotificationCenter.default
+                    .publisher(
+                        for: AVPlayerItem.mediaSelectionDidChangeNotification,
+                        object: playerItem)
+                    .flatMap { _ in captureAudioTrackInfo() }
+
+                let audioTrackPublisher = Publishers.Concatenate(
+                    prefix: captureAudioTrackInfo(),
+                    suffix: audioTrackChanges)
+                    // This can be a very noisy event stream, with intermediate states
+                    // reported for fractions of a second.
+                    .debounce(for: .seconds(minimumIntervalBetweenEvents), scheduler: DispatchQueue.global())
+                    .removeDuplicates { a, b in
+                        a.trackInfo == b.trackInfo
+                    }
+
+                return audioTrackPublisher
+                    .map { trackInfoAndTiming in
+                        MUXSDKAudioTrackChangeEvent(
+                            timing: trackInfoAndTiming.timing,
+                            trackInfo: trackInfoAndTiming.trackInfo)
+                    }
+            }
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension AVPlayerItem {
+    nonisolated func audioTrackChangeEvents() -> some Publisher<MUXSDKAudioTrackChangeEvent, Never> {
+        AudioTrackChangeEvents(playerItem: self).allEvents()
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension MUXSDKAudioTrackChangeEvent {
+    convenience init(timing: PlaybackEventTiming,
+                     trackInfo: AudioTrackChangeEvents.AudioTrackInfo?) {
+        if let trackInfo {
+            self.init(
+                audioTrackEnabled: true as NSNumber,
+                audioTrackName: trackInfo.name,
+                audioTrackLanguage: trackInfo.language,
+                audioTrackCodec: trackInfo.codec,
+                audioTrackBitrate: trackInfo.bitrate.map(NSNumber.init(value:)),
+                audioTrackChannels: trackInfo.channels)
+        } else {
+            self.init(
+                audioTrackEnabled: false as NSNumber,
+                audioTrackName: nil,
+                audioTrackLanguage: nil,
+                audioTrackCodec: nil,
+                audioTrackBitrate: nil,
+                audioTrackChannels: nil)
+        }
+
+        updateWithTiming(timing)
+    }
+}

--- a/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
@@ -4,6 +4,93 @@ import Combine
 @preconcurrency import MuxCore
 
 @available(iOS 15, tvOS 15, *)
+extension AudioFormatID {
+    var rfc6381CodecsParameterValue: String? {
+        // Explicit mappings only for common streaming-video audio codecs.
+        // Return nil for anything else rather than guessing.
+        switch self {
+        case kAudioFormatAC3:
+            return "ac-3"
+        case kAudioFormatEnhancedAC3:
+            return "ec-3"
+        case kAudioFormatMPEG4AAC:
+            return "mp4a.40.2"
+        case kAudioFormatMPEG4AAC_HE:
+            return "mp4a.40.5"
+        case kAudioFormatMPEG4AAC_HE_V2:
+            return "mp4a.40.29"
+        case kAudioFormatMPEGD_USAC:
+            return "mp4a.40.42"
+        case kAudioFormatOpus:
+            return "opus"
+        default:
+            return nil
+        }
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension MUXSDKAudioTrackChannelLayout {
+    init?(audioFormatDescription: CMAudioFormatDescription) {
+        var channelLayoutSize = 0
+        if let channelLayout = CMAudioFormatDescriptionGetChannelLayout(
+            audioFormatDescription,
+            sizeOut: &channelLayoutSize
+        ), channelLayout.pointee.mChannelLayoutTag.isAtmos {
+            self = .atmos
+            return
+        }
+
+        guard let audioFormat = CMAudioFormatDescriptionGetRichestDecodableFormat(audioFormatDescription)
+            ?? CMAudioFormatDescriptionGetMostCompatibleFormat(audioFormatDescription) else {
+            return nil
+        }
+
+        self.init(
+            channelCount: Int(audioFormat.pointee.mASBD.mChannelsPerFrame),
+            audioChannelLayoutTag: nil
+        )
+    }
+
+    init?(channelCount: Int, audioChannelLayoutTag: AudioChannelLayoutTag?) {
+        if let audioChannelLayoutTag, audioChannelLayoutTag.isAtmos {
+            self = .atmos
+            return
+        }
+
+        switch channelCount {
+        case 1:
+            self = .mono
+        case 2:
+            self = .stereo
+        case 6:
+            self = .fivePointOne
+        case 8:
+            self = .sevenPointOne
+        case let count where count > 0:
+            self = .init("\(count)")
+        default:
+            return nil
+        }
+    }
+}
+
+private extension AudioChannelLayoutTag {
+    var isAtmos: Bool {
+        switch self {
+        case kAudioChannelLayoutTag_Atmos_5_1_2,
+             kAudioChannelLayoutTag_Atmos_5_1_4,
+             kAudioChannelLayoutTag_Atmos_7_1_2,
+             kAudioChannelLayoutTag_Atmos_7_1_4,
+             kAudioChannelLayoutTag_Atmos_9_1_6:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
 struct AudioTrackChangeEvents {
 
     struct AudioTrackInfo: Equatable, Hashable, Sendable {
@@ -124,30 +211,11 @@ struct AudioTrackChangeEvents {
                 return nil
             }
 
-            return codecString(for: formatDescription.mediaSubType.rawValue)
+            return formatDescription.mediaSubType.rawValue.rfc6381CodecsParameterValue
         }
 
         static func codecString(for formatID: AudioFormatID) -> String? {
-            // Explicit mappings only for common streaming-video audio codecs.
-            // Return nil for anything else rather than guessing.
-            switch formatID {
-            case kAudioFormatAC3:
-                return "ac-3"
-            case kAudioFormatEnhancedAC3:
-                return "ec-3"
-            case kAudioFormatMPEG4AAC:
-                return "mp4a.40.2"
-            case kAudioFormatMPEG4AAC_HE:
-                return "mp4a.40.5"
-            case kAudioFormatMPEG4AAC_HE_V2:
-                return "mp4a.40.29"
-            case kAudioFormatMPEGD_USAC:
-                return "mp4a.40.42"
-            case kAudioFormatOpus:
-                return "opus"
-            default:
-                return nil
-            }
+            formatID.rfc6381CodecsParameterValue
         }
 
         static func channelLayout(for formatDescription: CMFormatDescription) -> MUXSDKAudioTrackChannelLayout? {
@@ -155,64 +223,14 @@ struct AudioTrackChangeEvents {
                 return nil
             }
 
-            let audioFormatDescription = formatDescription as CMAudioFormatDescription
-
-            var channelLayoutSize = 0
-            if let channelLayout = CMAudioFormatDescriptionGetChannelLayout(
-                audioFormatDescription,
-                sizeOut: &channelLayoutSize
-            ) {
-                let layoutTag = channelLayout.pointee.mChannelLayoutTag
-                if isAtmos(layoutTag: layoutTag) {
-                    return .atmos
-                }
-            }
-
-            guard let audioFormat = CMAudioFormatDescriptionGetRichestDecodableFormat(audioFormatDescription)
-                ?? CMAudioFormatDescriptionGetMostCompatibleFormat(audioFormatDescription) else {
-                return nil
-            }
-
-            return channelLayout(
-                channelCount: Int(audioFormat.pointee.mASBD.mChannelsPerFrame),
-                audioChannelLayoutTag: nil)
+            return .init(audioFormatDescription: formatDescription as CMAudioFormatDescription)
         }
 
         static func channelLayout(
             channelCount: Int,
             audioChannelLayoutTag: AudioChannelLayoutTag?
         ) -> MUXSDKAudioTrackChannelLayout? {
-            if let audioChannelLayoutTag, isAtmos(layoutTag: audioChannelLayoutTag) {
-                return .atmos
-            }
-
-            switch channelCount {
-            case 1:
-                return .mono
-            case 2:
-                return .stereo
-            case 6:
-                return .fivePointOne
-            case 8:
-                return .sevenPointOne
-            case let count where count > 0:
-                return .init("\(count)")
-            default:
-                return nil
-            }
-        }
-
-        private static func isAtmos(layoutTag: AudioChannelLayoutTag) -> Bool {
-            switch layoutTag {
-            case kAudioChannelLayoutTag_Atmos_5_1_2,
-                 kAudioChannelLayoutTag_Atmos_5_1_4,
-                 kAudioChannelLayoutTag_Atmos_7_1_2,
-                 kAudioChannelLayoutTag_Atmos_7_1_4,
-                 kAudioChannelLayoutTag_Atmos_9_1_6:
-                return true
-            default:
-                return false
-            }
+            .init(channelCount: channelCount, audioChannelLayoutTag: audioChannelLayoutTag)
         }
 
         private static func uniqueValue<T: Hashable>(_ values: [T]) -> T? {
@@ -294,7 +312,7 @@ extension MUXSDKAudioTrackChangeEvent {
                 audioTrackName: trackInfo.name,
                 audioTrackLanguage: trackInfo.language,
                 audioTrackCodec: trackInfo.codec,
-                audioTrackBitrate: trackInfo.bitrate.map(NSNumber.init(value:)),
+                audioTrackBitrate: trackInfo.bitrate as NSNumber?,
                 audioTrackChannels: trackInfo.channels)
         } else {
             self.init(

--- a/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
+++ b/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
@@ -41,6 +41,12 @@ extension PlayerMonitor {
             .sink(receiveValue: allEventsSubject.send)
             .store(in: &cancellables)
 
+        currentItemPublisher
+            .map { $0?.audioTrackChangeEvents().eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher() }
+            .switchToLatest()
+            .sink(receiveValue: allEventsSubject.send)
+            .store(in: &cancellables)
+
 #if !targetEnvironment(simulator)
         if #available(iOS 18.0, tvOS 18.0, visionOS 2.0, *) {
             currentItemPublisher

--- a/Tests/MUXSDKStatsInternalTests/AudioTrackChangeEventsTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/AudioTrackChangeEventsTests.swift
@@ -1,0 +1,111 @@
+import AudioToolbox
+import CoreMedia
+import MuxCore
+@testable import MUXSDKStatsInternal
+import Testing
+
+struct AudioTrackChangeEventsTests {
+    @Test(arguments: [
+        (1, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout.mono),
+        (2, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout.stereo),
+        (6, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout.fivePointOne),
+        (8, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout.sevenPointOne),
+        (3, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout("3")),
+        (2, kAudioChannelLayoutTag_Atmos_5_1_2, MUXSDKAudioTrackChannelLayout.atmos),
+    ])
+    func channelLayoutMapping(
+        channelCount: Int,
+        layoutTag: AudioChannelLayoutTag?,
+        expected: MUXSDKAudioTrackChannelLayout?
+    ) {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        #expect(
+            AudioTrackChangeEvents.AssetTrackInfo.channelLayout(
+                channelCount: channelCount,
+                audioChannelLayoutTag: layoutTag
+            ) == expected
+        )
+    }
+
+    @Test(arguments: [
+        (AudioFormatID(kAudioFormatAC3), "ac-3"),
+        (AudioFormatID(kAudioFormatEnhancedAC3), "ec-3"),
+        (AudioFormatID(kAudioFormatMPEG4AAC), "mp4a.40.2"),
+        (AudioFormatID(kAudioFormatMPEG4AAC_HE), "mp4a.40.5"),
+        (AudioFormatID(kAudioFormatMPEG4AAC_HE_V2), "mp4a.40.29"),
+        (AudioFormatID(kAudioFormatMPEGD_USAC), "mp4a.40.42"),
+        (AudioFormatID(kAudioFormatOpus), "opus"),
+        (AudioFormatID(kAudioFormatAppleLossless), nil),
+    ])
+    func codecMapping(formatID: AudioFormatID, expected: String?) {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        #expect(AudioTrackChangeEvents.AssetTrackInfo.codecString(for: formatID) == expected)
+    }
+
+    @Test
+    func disabledEventOmitsOptionalMetadata() throws {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let event = MUXSDKAudioTrackChangeEvent(
+            timing: PlaybackEventTiming(
+                mediaTime: .zero,
+                programDate: nil,
+                liveEdgeProgramDate: nil),
+            trackInfo: nil)
+
+        let playerData = try #require(event.playerData)
+
+        #expect(event.playerAudioTrackEnabled as? Bool == false)
+        #expect(event.playerAudioTrackName == nil)
+        #expect(event.playerAudioTrackLanguage == nil)
+        #expect(event.playerAudioTrackCodec == nil)
+        #expect(event.playerAudioTrackBitrate == nil)
+        #expect(event.playerAudioTrackChannels == nil)
+        #expect(playerData.playerAudioTrackEnabled as? Bool == false)
+    }
+
+    @Test
+    func selectedEventPreservesAllExtractedMetadata() throws {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let event = MUXSDKAudioTrackChangeEvent(
+            audioTrackEnabled: true as NSNumber,
+            audioTrackName: "English",
+            audioTrackLanguage: "en-US",
+            audioTrackCodec: "ec-3",
+            audioTrackBitrate: 128_000,
+            audioTrackChannels: MUXSDKAudioTrackChannelLayout.stereo)
+
+        event.updateWithTiming(
+            PlaybackEventTiming(
+                mediaTime: CMTime(seconds: 12.345, preferredTimescale: 1000),
+                programDate: Date(timeIntervalSince1970: 100),
+                liveEdgeProgramDate: nil))
+
+        let playerData = try #require(event.playerData)
+
+        #expect(event.playerAudioTrackEnabled as? Bool == true)
+        #expect(event.playerAudioTrackName == "English")
+        #expect(event.playerAudioTrackLanguage == "en-US")
+        #expect(event.playerAudioTrackCodec == "ec-3")
+        #expect(event.playerAudioTrackBitrate?.intValue == 128_000)
+        #expect(event.playerAudioTrackChannels == MUXSDKAudioTrackChannelLayout.stereo)
+        #expect(playerData.playerAudioTrackEnabled as? Bool == true)
+        #expect(playerData.playerAudioTrackName == "English")
+        #expect(playerData.playerAudioTrackLanguage == "en-US")
+        #expect(playerData.playerAudioTrackCodec == "ec-3")
+        #expect(playerData.playerAudioTrackBitrate?.intValue == 128_000)
+        #expect(playerData.playerAudioTrackChannels == MUXSDKAudioTrackChannelLayout.stereo)
+        #expect(playerData.playerPlayheadTime?.intValue == 12_345)
+    }
+}

--- a/Tests/MUXSDKStatsInternalTests/AudioTrackChangeEventsTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/AudioTrackChangeEventsTests.swift
@@ -1,8 +1,33 @@
+@preconcurrency import AVFoundation
 import AudioToolbox
 import CoreMedia
-import MuxCore
+@preconcurrency import MuxCore
 @testable import MUXSDKStatsInternal
 import Testing
+
+private let multiAudioTestStreamURL = URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8")!
+private let describesVideoCharacteristic = AVMediaCharacteristic("public.accessibility.describes-video")
+
+@available(iOS 15, tvOS 15, *)
+@MainActor
+private func waitForTrackInfo(
+    on playerItem: AVPlayerItem,
+    named expectedName: String,
+    timeout: TimeInterval = 30
+) async throws -> AudioTrackChangeEvents.AudioTrackInfo {
+    let timeoutDate = Date().addingTimeInterval(timeout)
+
+    while Date() < timeoutDate {
+        if let trackInfo = await AudioTrackChangeEvents.AudioTrackInfo(playerItem),
+           trackInfo.name == expectedName {
+            return trackInfo
+        }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+    }
+
+    throw TimeoutError()
+}
 
 struct AudioTrackChangeEventsTests {
     @Test(arguments: [
@@ -107,5 +132,32 @@ struct AudioTrackChangeEventsTests {
         #expect(playerData.playerAudioTrackBitrate?.intValue == 128_000)
         #expect(playerData.playerAudioTrackChannels == MUXSDKAudioTrackChannelLayout.stereo)
         #expect(playerData.playerPlayheadTime?.intValue == 12_345)
+    }
+
+    @MainActor
+    @Test
+    func audibleMediaSelectionChangePublishesUpdatedTrackInfo() async throws {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let playerItem = AVPlayerItem(url: multiAudioTestStreamURL)
+
+        let initialTrackInfo = try await waitForTrackInfo(on: playerItem, named: "English")
+        #expect(initialTrackInfo.language == "en-US")
+
+        let audibleGroup = try #require(
+            try await playerItem.asset.loadMediaSelectionGroup(for: .audible)
+        )
+        let dvsOption = try #require(audibleGroup.options.first(where: {
+            $0.hasMediaCharacteristic(describesVideoCharacteristic)
+        }))
+
+        await MainActor.run {
+            playerItem.select(dvsOption, in: audibleGroup)
+        }
+
+        let changedTrackInfo = try await waitForTrackInfo(on: playerItem, named: "English (DVS)")
+        #expect(changedTrackInfo.language == "en-US")
     }
 }


### PR DESCRIPTION
[NAT-412]

## Summary
- add AVPlayer audio track change emission and wire it into PlayerMonitor
- emit initial and change events with best-effort audio track metadata
- add focused internal tests and update ObjC dependency pins for the merged audio API branch

## Test plan
- [x] Unit tests: `AudioTrackChangeEventsTests` (codec / channel mapping + event construction)
- [x] Builds for iOS Simulator
- [x] Manual playback verification on a sample with audio track switching
- [x] Manual verification on Mux Dashboard

## Dependencies
- Depends on `mux-stats-sdk-objc` branch `feature/nat-416-audio-track-changes` (audio API merged there).

[NAT-412]: https://mux1.atlassian.net/browse/NAT-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new audio track change event generation and wires it into the main `PlayerMonitor` event stream; behavior depends on AVFoundation media selection timing and best-effort metadata extraction, so there’s some risk of noisy/incorrect events or performance impact in playback scenarios.
> 
> **Overview**
> Adds **audio track change event** support for `AVPlayerItem` on iOS/tvOS 15+, emitting an initial event plus subsequent updates when `mediaSelectionDidChange` fires, with best-effort metadata (name, language, RFC6381 codec string, bitrate, and channel layout including Atmos) and debouncing/deduping to reduce noise.
> 
> Wires these `MUXSDKAudioTrackChangeEvent`s into `PlayerMonitor` alongside existing rendition/text track monitoring, adds focused unit/integration-style tests for codec/channel mapping and event construction/selection changes, and updates the `mux-stats-sdk-objc` SPM dependency pins to the `feature/nat-416-audio-track-changes` branch/revision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaf868c64d8a1455fab0eedda034f738797c4c3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->