### PR TITLE
NAT-333 text track changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/muxinc/stats-sdk-objc.git",
-            from: "5.11.0"),
+            from: "5.12.0"),
     ],
     targets: [
         .target(

--- a/Sources/MUXSDKStatsInternal/Features/TextTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/TextTrackChangeEvents.swift
@@ -1,0 +1,231 @@
+import AVFoundation
+import Combine
+@preconcurrency import MuxCore
+
+extension MUXSDKTextTrackType {
+    init?(_ mediaType: AVMediaType) {
+        switch mediaType {
+        case .subtitle:
+            self = .subtitles
+        case .closedCaption:
+            self = .closedCaptions
+        default:
+            return nil
+        }
+    }
+
+    @available(iOS 13, tvOS 13, *)
+    var formatDescriptionMediaType: CMFormatDescription.MediaType? {
+        switch self {
+        case .closedCaptions:
+            .closedCaption
+        case .subtitles:
+            .subtitle
+        default:
+            nil
+        }
+    }
+}
+
+@available(iOS 13, tvOS 13, *)
+extension MUXSDKTextTrackFormat {
+    init?(_ mediaSubType: CMFormatDescription.MediaSubType) {
+        switch mediaSubType {
+        case .cea608:
+            self = .cea608
+        case .cea708:
+            self = .cea708
+        case .webVTT:
+            self = .webVTT
+        default:
+            return nil
+        }
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+struct TextTrackChangeEvents {
+
+    /// Represents the selected text track option (see AVMediaSelectionOption) but not necessarily the current presentation state
+    struct LegibleMediaSelectionOptionInfo: Equatable, Hashable, Sendable {
+        let name: String
+        let mediaType: AVMediaType
+        let language: String?
+
+        var trackType: MUXSDKTextTrackType? {
+            MUXSDKTextTrackType(mediaType)
+        }
+
+        @MainActor
+        init?(_ mediaSelection: AVMediaSelection) async {
+            guard let mediaSelectionOption = await mediaSelection.selectedMediaOptionInGroup(for: .legible) else {
+                return nil
+            }
+
+            mediaType = mediaSelectionOption.mediaType
+
+            if let hlsName = await mediaSelectionOption.loadHLSNameAttributeValue() {
+                name = hlsName
+            } else if let title = await mediaSelectionOption.loadTitle() {
+                name = title
+            } else {
+                // This will be in the user's locale, so it is lowest preference
+                name = mediaSelectionOption.displayName
+            }
+
+            language = mediaSelectionOption.extendedLanguageTag
+        }
+    }
+
+    /// Represents the current presentation state (see AVAssetTrack), unfortunately containing minimal information about the source option
+    struct AssetTrackInfo: Equatable, Hashable, Sendable {
+        let trackType: MUXSDKTextTrackType
+        let trackFormat: MUXSDKTextTrackFormat
+
+        @MainActor
+        init?(_ assetTrack: AVAssetTrack) async {
+            guard let trackType = MUXSDKTextTrackType(assetTrack.mediaType),
+                  let formatDescriptionMediaType = trackType.formatDescriptionMediaType else {
+                    return nil
+                }
+
+            let formatDescriptions: [CMFormatDescription]
+            do {
+                formatDescriptions = try await assetTrack.load(.formatDescriptions)
+            } catch {
+                logger.debug("Failed to load format descriptions on \(assetTrack): \(error)")
+                return nil
+            }
+
+            guard let trackFormat = formatDescriptions
+                .filter({ $0.mediaType == formatDescriptionMediaType })
+                .compactMap({ MUXSDKTextTrackFormat($0.mediaSubType) })
+                .first else {
+                return nil
+            }
+
+            self.trackType = trackType
+            self.trackFormat = trackFormat
+        }
+    }
+
+    let playerItem: AVPlayerItem
+    let minimumIntervalBetweenEvents: TimeInterval
+
+    init(playerItem: AVPlayerItem, minimumIntervalBetweenEvents: TimeInterval = 0.25) {
+        self.playerItem = playerItem
+        self.minimumIntervalBetweenEvents = minimumIntervalBetweenEvents
+    }
+
+    func allEvents() -> some Publisher<MUXSDKTextTrackChangeEvent, Never> {
+        playerItem.readyToPlayPublisher
+            .catch { _ in
+                // Ignore status failed error
+                return Empty<AVPlayerItem, Never>()
+            }
+            .flatMap { playerItem in
+
+                let captureMediaSelectionOption = {
+                    Future(priority: .userInitiated) { @MainActor in
+                        async let timing = await playerItem.currentTiming()
+
+                        let selectionInfo = await LegibleMediaSelectionOptionInfo(playerItem.currentMediaSelection)
+
+                        return (
+                            timing: await timing,
+                            selectionInfo: selectionInfo
+                        )
+                    }
+                }
+
+                let mediaSelectionOptionChanges = NotificationCenter.default
+                    .publisher(
+                        for: AVPlayerItem.mediaSelectionDidChangeNotification,
+                        object: playerItem)
+                    .flatMap { _ in captureMediaSelectionOption() }
+
+                let mediaSelectionOptionPublisher = Publishers.Concatenate(
+                    prefix: captureMediaSelectionOption(),
+                    suffix: mediaSelectionOptionChanges)
+                // This can be a very noisy event stream, with intermediate states reported for fractions of a second:
+                    .debounce(for: .seconds(minimumIntervalBetweenEvents), scheduler: DispatchQueue.global())
+                    .removeDuplicates { a, b in
+                        a.selectionInfo == b.selectionInfo
+                    }
+
+                return mediaSelectionOptionPublisher
+                    .map { @MainActor selectionOptionAndTiming in
+                        let timing = selectionOptionAndTiming.timing
+
+                        guard let selectionOption = selectionOptionAndTiming.selectionInfo else {
+                            // No text track
+                            return MUXSDKTextTrackChangeEvent(
+                                timing: timing,
+                                selectionOption: nil)
+                        }
+
+                        // Attempt to match presented tracks
+                        for track in playerItem.tracks {
+                            if let assetTrack = track.assetTrack,
+                               assetTrack.mediaType == selectionOption.mediaType,
+                               let trackInfo = await AssetTrackInfo(assetTrack),
+                               trackInfo.trackType == selectionOption.trackType {
+                                return MUXSDKTextTrackChangeEvent(
+                                    timing: timing,
+                                    selectionOption: selectionOption,
+                                    assetTrack: trackInfo)
+                            }
+                        }
+
+                        // Report all available info without matched track
+                        return MUXSDKTextTrackChangeEvent(
+                            timing: timing,
+                            selectionOption: selectionOption,
+                            assetTrack: nil)
+                    }
+            }
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension AVPlayerItem {
+    nonisolated func textTrackChangeEvents() -> some Publisher<MUXSDKTextTrackChangeEvent, Never> {
+        TextTrackChangeEvents(playerItem: self).allEvents()
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension MUXSDKTextTrackChangeEvent {
+    convenience init(timing: PlaybackEventTiming,
+                     selectionOption: TextTrackChangeEvents.LegibleMediaSelectionOptionInfo?) {
+        if let selectionOption {
+            self.init(
+                timing: timing,
+                selectionOption: selectionOption,
+                assetTrack: nil)
+            return
+        }
+
+        self.init(
+            textTrackEnabled: false as NSNumber,
+            textTrackType: nil,
+            textTrackFormat: nil,
+            textTrackName: nil,
+            textTrackLanguage: nil)
+
+        updateWithTiming(timing)
+    }
+
+    convenience init(timing: PlaybackEventTiming,
+                     selectionOption: TextTrackChangeEvents.LegibleMediaSelectionOptionInfo,
+                     assetTrack: TextTrackChangeEvents.AssetTrackInfo?) {
+        self.init(
+            textTrackEnabled: true as NSNumber,
+            textTrackType: selectionOption.trackType,
+            textTrackFormat: assetTrack?.trackFormat,
+            textTrackName: selectionOption.name,
+            textTrackLanguage: selectionOption.language)
+
+        updateWithTiming(timing)
+    }
+}

--- a/Sources/MUXSDKStatsInternal/MuxCore/MUXSDKPlaybackEvent+Extensions.swift
+++ b/Sources/MUXSDKStatsInternal/MuxCore/MUXSDKPlaybackEvent+Extensions.swift
@@ -1,0 +1,18 @@
+import MuxCore
+
+extension MUXSDKPlaybackEvent {
+
+    var lazyPlayerData: MUXSDKPlayerData {
+        if let playerData {
+            return playerData
+        }
+        let created = MUXSDKPlayerData()
+        self.playerData = created
+        return created
+    }
+
+    @available(iOS 13, tvOS 13, *)
+    func updateWithTiming(_ timing: PlaybackEventTiming) {
+        lazyPlayerData.updateWithTiming(timing)
+    }
+}

--- a/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
+++ b/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
@@ -35,6 +35,12 @@ extension PlayerMonitor {
             .sink(receiveValue: allEventsSubject.send)
             .store(in: &cancellables)
 
+        currentItemPublisher
+            .map { $0?.textTrackChangeEvents().eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher() }
+            .switchToLatest()
+            .sink(receiveValue: allEventsSubject.send)
+            .store(in: &cancellables)
+
 #if !targetEnvironment(simulator)
         if #available(iOS 18.0, tvOS 18.0, visionOS 2.0, *) {
             currentItemPublisher

--- a/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
@@ -9,19 +9,18 @@ extension AVPlayerItem {
         var playerItemError: Error?
     }
 
-    /// Publishes `tracks` once initial loading completes, failing when overall loading fails
-    nonisolated var tracksReadyToPlayPublisher: some Publisher<[AVPlayerItemTrack], StatusFailedError> {
+    /// Publishes `self` once initial loading completes, failing when overall loading fails
+    nonisolated var readyToPlayPublisher: some Publisher<AVPlayerItem, StatusFailedError> {
         publisher(for: \.status, options: [.initial])
             .removeDuplicates()
             .map { status in
                 switch status {
                 case .unknown:
-                    return Empty<[AVPlayerItemTrack], StatusFailedError>()
+                    return Empty<AVPlayerItem, StatusFailedError>()
                         .eraseToAnyPublisher()
 
                 case .readyToPlay:
-                    return self.publisher(for: \.tracks, options: [.initial])
-                        .removeDuplicates()
+                    return Just(self)
                         .setFailureType(to: StatusFailedError.self)
                         .eraseToAnyPublisher()
 
@@ -37,7 +36,11 @@ extension AVPlayerItem {
     }
 
     nonisolated func timedRenditionInfoPublisher() -> some Publisher<(PlaybackEventTiming, MUXSDKVideoData), StatusFailedError> {
-        tracksReadyToPlayPublisher
+        readyToPlayPublisher
+            .flatMap { playerItem in
+                playerItem.publisher(for: \.tracks, options: [.initial])
+                    .removeDuplicates()
+            }
             // @MainActor isolated: AVPlayerItemTrack (and therefore its assetTrack property)
             .receive(on: ImmediateIfOnMainQueueScheduler.shared)
             .map { (tracks: [AVPlayerItemTrack]) -> AVAssetTrack? in

--- a/Sources/MUXSDKStatsInternal/Utilities/AVMediaSelection+Extensions.swift
+++ b/Sources/MUXSDKStatsInternal/Utilities/AVMediaSelection+Extensions.swift
@@ -1,0 +1,26 @@
+import AVFoundation
+
+@available(iOS 15, tvOS 15, *)
+extension AVMediaSelection {
+
+    @MainActor
+    func selectedMediaOptionInGroup(for mediaCharacteristic: AVMediaCharacteristic) async -> AVMediaSelectionOption? {
+        guard let asset else {
+            return nil
+        }
+
+        let group: AVMediaSelectionGroup?
+        do {
+            group = try await asset.loadMediaSelectionGroup(for: mediaCharacteristic)
+        } catch {
+            logger.debug("Failed to load group for \(mediaCharacteristic.rawValue): \(error)")
+            return nil
+        }
+
+        guard let group, let selected = selectedMediaOption(in: group) else {
+            return nil
+        }
+
+        return selected
+    }
+}

--- a/Sources/MUXSDKStatsInternal/Utilities/AVMediaSelectionOption+Extensions.swift
+++ b/Sources/MUXSDKStatsInternal/Utilities/AVMediaSelectionOption+Extensions.swift
@@ -1,0 +1,39 @@
+import AVFoundation
+
+extension AVMetadataIdentifier {
+
+    static let hlsNameAttribute = AVMetadataIdentifier("m3u8/NAME")
+}
+
+@available(iOS 15, tvOS 15, *)
+extension AVMediaSelectionOption {
+
+    @MainActor
+    func loadHLSNameAttributeValue() async -> String? {
+        await loadFirstStringValue(for: .hlsNameAttribute)
+    }
+
+    @MainActor
+    func loadTitle() async -> String? {
+        await loadFirstStringValue(for: .commonIdentifierTitle)
+    }
+
+    @MainActor
+    func loadFirstStringValue(for identifier: AVMetadataIdentifier) async -> String? {
+        let metadataItems = AVMetadataItem.metadataItems(
+            from: commonMetadata,
+            filteredByIdentifier: identifier)
+
+        for item in metadataItems {
+            do {
+                if let stringValue = try await item.load(.stringValue) {
+                    return stringValue
+                }
+            } catch {
+                logger.debug("Failed to load metadata item \(item): \(error)")
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/MUXSDKStatsInternal/Utilities/Publisher+Extensions.swift
+++ b/Sources/MUXSDKStatsInternal/Utilities/Publisher+Extensions.swift
@@ -1,0 +1,14 @@
+import Combine
+
+@available(iOS 14, tvOS 14, *)
+extension Publisher {
+
+    /// Transforms all elements from the upstream publisher with a provided async closure, waiting for completion before advancing to the next element.
+    func map<T>(isolation: isolated (any Actor)? = #isolation, priority: TaskPriority? = nil, _ transform: @escaping (Self.Output) async -> sending T) -> some Publisher<T, Failure> {
+        flatMap(maxPublishers: .max(1)) { value in
+            Future(isolation: isolation, priority: priority) {
+                await transform(value)
+            }
+        }
+    }
+}

--- a/Tests/MUXSDKStatsInternalTests/AVFoundation+TestHelpers.swift
+++ b/Tests/MUXSDKStatsInternalTests/AVFoundation+TestHelpers.swift
@@ -1,0 +1,21 @@
+import AVFoundation
+@testable import MUXSDKStatsInternal
+
+extension AVPlayerItem {
+
+    @available(iOS 15, tvOS 15, *)
+    nonisolated(nonsending) func waitForReadyToPlay() async throws(StatusFailedError) {
+        for await status in publisher(for: \.status, options: .initial).removeDuplicates().buffer(size: 2, prefetch: .byRequest, whenFull: .dropOldest).values {
+            switch status {
+            case .unknown:
+                ()
+            case .readyToPlay:
+                return
+            case .failed:
+                throw StatusFailedError(playerItemError: error)
+            @unknown default:
+                fatalError("unknown status \(status)")
+            }
+        }
+    }
+}

--- a/Tests/MUXSDKStatsInternalTests/Features/TextTrackChangeEventsTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/Features/TextTrackChangeEventsTests.swift
@@ -1,0 +1,345 @@
+import AVFoundation
+@preconcurrency import MuxCore
+@testable import MUXSDKStatsInternal
+import Testing
+
+// has cc and subtitle track
+let bipBopExampleURL = URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8")!
+
+struct TextTrackChangeEventsTests {
+
+    @available(iOS 15, tvOS 15, *)
+    @Test func initialEventPreloadOnPlayerItem() async throws {
+        try await confirmation("an initial event should fire when added to unloaded item", expectedCount: 1) { confirmation in
+            let player = AVPlayer()
+            player.appliesMediaSelectionCriteriaAutomatically = false
+            let playerItem = AVPlayerItem(url: bipBopExampleURL)
+
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                let ccOption = try #require(group.options.first(where: { $0.mediaType == .closedCaption }))
+                playerItem.select(ccOption, in: group)
+            }()
+
+            let ttce = TextTrackChangeEvents(playerItem: playerItem)
+
+            let events = ttce.allEvents()
+                .handleEvents(receiveOutput: { _ in confirmation() })
+                .buffer(size: 10, prefetch: .byRequest, whenFull: .dropOldest)
+                .values
+
+            var iterator = events.makeAsyncIterator()
+
+            player.replaceCurrentItem(with: playerItem)
+
+            try await playerItem.waitForReadyToPlay()
+
+            let event = try #require(await iterator.next())
+            #expect(event.playerData?.playerPlayheadTime == 0 as NSNumber)
+            #expect(event.playerTextTrackEnabled == true as NSNumber)
+            #expect(event.playerTextTrackName == "English")
+            #expect(event.playerTextTrackType == .closedCaptions)
+            #expect(event.playerTextTrackFormat == .cea608)
+            #expect(event.playerTextTrackLanguage == "en")
+        }
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    @Test func emptyInitialEventPreloadOnPlayerItem() async throws {
+        try await confirmation("an initial event should fire when added to unloaded item", expectedCount: 1) { confirmation in
+            let player = AVPlayer()
+            player.appliesMediaSelectionCriteriaAutomatically = false
+            let playerItem = AVPlayerItem(url: bipBopExampleURL)
+
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                playerItem.select(nil, in: group)
+            }()
+
+            let ttce = TextTrackChangeEvents(playerItem: playerItem)
+
+            let events = ttce.allEvents()
+                .handleEvents(receiveOutput: { _ in confirmation() })
+                .buffer(size: 10, prefetch: .byRequest, whenFull: .dropOldest)
+                .values
+
+            var iterator = events.makeAsyncIterator()
+
+            player.replaceCurrentItem(with: playerItem)
+
+            try await playerItem.waitForReadyToPlay()
+
+            let event = try #require(await iterator.next())
+            #expect(event.playerData?.playerPlayheadTime == 0 as NSNumber)
+            #expect(event.playerTextTrackEnabled == false as NSNumber)
+            #expect(event.playerTextTrackName == nil)
+            #expect(event.playerTextTrackType == nil)
+            #expect(event.playerTextTrackFormat == nil)
+            #expect(event.playerTextTrackLanguage == nil)
+        }
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    @Test func initialEventOnReadyItem() async throws {
+        try await confirmation("an initial event should fire when added to ready item", expectedCount: 1) { confirmation in
+            let player = AVPlayer()
+            player.appliesMediaSelectionCriteriaAutomatically = false
+            let playerItem = AVPlayerItem(url: bipBopExampleURL)
+
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                let ccOption = try #require(group.options.first(where: { $0.mediaType == .closedCaption }))
+                playerItem.select(ccOption, in: group)
+            }()
+
+            player.replaceCurrentItem(with: playerItem)
+
+            try await playerItem.waitForReadyToPlay()
+
+            let ttce = TextTrackChangeEvents(playerItem: playerItem)
+
+            let events = ttce.allEvents()
+                .handleEvents(receiveOutput: { _ in confirmation() })
+                .buffer(size: 10, prefetch: .byRequest, whenFull: .dropOldest)
+                .values
+
+            var iterator = events.makeAsyncIterator()
+
+            let event = try #require(await iterator.next())
+            #expect(event.playerData?.playerPlayheadTime == 0 as NSNumber)
+            #expect(event.playerTextTrackEnabled == true as NSNumber)
+            #expect(event.playerTextTrackName == "English")
+            #expect(event.playerTextTrackType == .closedCaptions)
+            #expect(event.playerTextTrackFormat == .cea608)
+            #expect(event.playerTextTrackLanguage == "en")
+        }
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    @Test func emptyInitialEventOnReadyItem() async throws {
+        try await confirmation("an initial event should fire when added to ready item", expectedCount: 1) { confirmation in
+            let player = AVPlayer()
+            player.appliesMediaSelectionCriteriaAutomatically = false
+            let playerItem = AVPlayerItem(url: bipBopExampleURL)
+
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                playerItem.select(nil, in: group)
+            }()
+
+            player.replaceCurrentItem(with: playerItem)
+
+            try await playerItem.waitForReadyToPlay()
+
+            let ttce = TextTrackChangeEvents(playerItem: playerItem)
+
+            let events = ttce.allEvents()
+                .handleEvents(receiveOutput: { _ in confirmation() })
+                .buffer(size: 10, prefetch: .byRequest, whenFull: .dropOldest)
+                .values
+
+            var iterator = events.makeAsyncIterator()
+
+            let event = try #require(await iterator.next())
+            #expect(event.playerData?.playerPlayheadTime == 0 as NSNumber)
+            #expect(event.playerTextTrackEnabled == false as NSNumber)
+            #expect(event.playerTextTrackName == nil)
+            #expect(event.playerTextTrackType == nil)
+            #expect(event.playerTextTrackFormat == nil)
+            #expect(event.playerTextTrackLanguage == nil)
+        }
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    @Test func initialEventOnPlayingItem() async throws {
+        try await confirmation("an initial event should fire when added to a playing item", expectedCount: 1) { confirmation in
+            let player = AVPlayer()
+            player.appliesMediaSelectionCriteriaAutomatically = false
+            let playerItem = AVPlayerItem(url: bipBopExampleURL)
+
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                let ccOption = try #require(group.options.first(where: { $0.mediaType == .closedCaption }))
+                playerItem.select(ccOption, in: group)
+            }()
+
+            player.replaceCurrentItem(with: playerItem)
+
+            try await playerItem.waitForReadyToPlay()
+
+            await MainActor.run {
+                player.play()
+            }
+
+            try await Task.sleep(nanoseconds: NSEC_PER_SEC * 1)
+
+            let timeBeforeAttach = try #require(playerItem.currentTime().muxTimeValue)
+
+            let ttce = TextTrackChangeEvents(playerItem: playerItem)
+
+            let events = ttce.allEvents()
+                .handleEvents(receiveOutput: { _ in confirmation() })
+                .buffer(size: 10, prefetch: .byRequest, whenFull: .dropOldest)
+                .values
+
+            var iterator = events.makeAsyncIterator()
+
+            let event = try #require(await iterator.next())
+            let playheadTime = try #require(event.playerData?.playerPlayheadTime)
+            #expect(playheadTime.compare(timeBeforeAttach) != .orderedAscending)
+            #expect(event.playerTextTrackEnabled == true as NSNumber)
+            #expect(event.playerTextTrackName == "English")
+            #expect(event.playerTextTrackType == .closedCaptions)
+            #expect(event.playerTextTrackFormat == .cea608)
+            #expect(event.playerTextTrackLanguage == "en")
+        }
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    @Test func changeEventIsFired() async throws {
+        try await confirmation("three events are fired", expectedCount: 3) { confirmation in
+            let player = AVPlayer()
+            player.appliesMediaSelectionCriteriaAutomatically = false
+            let playerItem = AVPlayerItem(url: bipBopExampleURL)
+
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                playerItem.select(nil, in: group)
+            }()
+
+            player.replaceCurrentItem(with: playerItem)
+
+            let ttce = TextTrackChangeEvents(playerItem: playerItem)
+
+            let events = ttce.allEvents()
+                .handleEvents(receiveOutput: { _ in confirmation() })
+                .buffer(size: 10, prefetch: .byRequest, whenFull: .dropOldest)
+                .values
+
+            var iterator = events.makeAsyncIterator()
+
+            await MainActor.run {
+                player.play()
+            }
+
+            let firstEvent = try #require(await iterator.next())
+            #expect(firstEvent.playerData?.playerPlayheadTime == 0 as NSNumber)
+            #expect(firstEvent.playerTextTrackEnabled == false as NSNumber)
+            #expect(firstEvent.playerTextTrackName == nil)
+            #expect(firstEvent.playerTextTrackType == nil)
+            #expect(firstEvent.playerTextTrackFormat == nil)
+            #expect(firstEvent.playerTextTrackLanguage == nil)
+
+            try await Task.sleep(nanoseconds: NSEC_PER_SEC/2)
+
+            let timeBeforeSecondEvent = try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                let ccOption = try #require(group.options.first(where: { $0.mediaType == .closedCaption }))
+                defer {
+                    playerItem.select(ccOption, in: group)
+                }
+                return try #require(playerItem.currentTime().muxTimeValue)
+            }()
+
+            let secondEvent = try #require(await iterator.next())
+            #expect(try #require(secondEvent.playerData?.playerPlayheadTime).compare(timeBeforeSecondEvent) != .orderedAscending)
+            #expect(secondEvent.playerTextTrackEnabled == true as NSNumber)
+            #expect(secondEvent.playerTextTrackName == "English")
+            #expect(secondEvent.playerTextTrackType == .closedCaptions)
+            #expect(secondEvent.playerTextTrackFormat == .cea608)
+            #expect(secondEvent.playerTextTrackLanguage == "en")
+
+            try await Task.sleep(nanoseconds: NSEC_PER_SEC/2)
+
+            let timeBeforeThirdEvent = try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                let subtitleOption = try #require(group.options.first(where: { $0.mediaType == .subtitle }))
+                defer {
+                    playerItem.select(subtitleOption, in: group)
+                }
+                return try #require(playerItem.currentTime().muxTimeValue)
+            }()
+
+            let thirdEvent = try #require(await iterator.next())
+            #expect(try #require(thirdEvent.playerData?.playerPlayheadTime).compare(timeBeforeThirdEvent) != .orderedAscending)
+            #expect(thirdEvent.playerTextTrackEnabled == true as NSNumber)
+            #expect(thirdEvent.playerTextTrackName == "English")
+            #expect(thirdEvent.playerTextTrackType == .subtitles)
+            // This matching occasionally fails, so the value can be missing but must not be incorrect:
+            #expect([.webVTT, nil].contains(thirdEvent.playerTextTrackFormat))
+            #expect(thirdEvent.playerTextTrackLanguage == "en")
+        }
+    }
+
+    @available(iOS 15, tvOS 15, *)
+    @Test func smoothsBurstOfEvents() async throws {
+        try await confirmation("two events are fired", expectedCount: 2) { confirmation in
+            let player = AVPlayer()
+            player.appliesMediaSelectionCriteriaAutomatically = false
+            let playerItem = AVPlayerItem(url: bipBopExampleURL)
+
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                playerItem.select(nil, in: group)
+            }()
+
+            player.replaceCurrentItem(with: playerItem)
+
+            let ttce = TextTrackChangeEvents(playerItem: playerItem)
+
+            let events = ttce.allEvents()
+                .handleEvents(receiveOutput: { _ in confirmation() })
+                .buffer(size: 10, prefetch: .byRequest, whenFull: .dropOldest)
+                .values
+
+            var iterator = events.makeAsyncIterator()
+
+            await MainActor.run {
+                player.play()
+            }
+
+            let firstEvent = try #require(await iterator.next())
+            #expect(firstEvent.playerData?.playerPlayheadTime == 0 as NSNumber)
+            #expect(firstEvent.playerTextTrackEnabled == false as NSNumber)
+            #expect(firstEvent.playerTextTrackName == nil)
+            #expect(firstEvent.playerTextTrackType == nil)
+            #expect(firstEvent.playerTextTrackFormat == nil)
+            #expect(firstEvent.playerTextTrackLanguage == nil)
+
+            try await Task.sleep(nanoseconds: NSEC_PER_SEC/2)
+
+            // would generate an event with subtitles enabled
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                let subtitleOption = try #require(group.options.first(where: { $0.mediaType == .subtitle }))
+                playerItem.select(subtitleOption, in: group)
+            }()
+
+            // would generate an event with no track
+            try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                playerItem.select(nil, in: group)
+            }()
+
+            // should generate an event with cc enabled
+            let timeBeforeSecondEvent = try await { @MainActor in
+                let group = try #require(await playerItem.asset.loadMediaSelectionGroup(for: .legible))
+                let ccOption = try #require(group.options.first(where: { $0.mediaType == .closedCaption }))
+                defer {
+                    playerItem.select(ccOption, in: group)
+                }
+                return try #require(playerItem.currentTime().muxTimeValue)
+            }()
+
+            let secondEvent = try #require(await iterator.next())
+            #expect(try #require(secondEvent.playerData?.playerPlayheadTime).compare(timeBeforeSecondEvent) != .orderedAscending)
+            #expect(secondEvent.playerTextTrackEnabled == true as NSNumber)
+            #expect(secondEvent.playerTextTrackName == "English")
+            #expect(secondEvent.playerTextTrackType == .closedCaptions)
+            #expect(secondEvent.playerTextTrackFormat == .cea608)
+            #expect(secondEvent.playerTextTrackLanguage == "en")
+
+            try await Task.sleep(nanoseconds: NSEC_PER_SEC/2)
+        }
+    }
+}

--- a/Tests/MUXSDKStatsInternalTests/Features/TextTrackChangeEventsTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/Features/TextTrackChangeEventsTests.swift
@@ -223,7 +223,6 @@ struct TextTrackChangeEventsTests {
             }
 
             let firstEvent = try #require(await iterator.next())
-            #expect(firstEvent.playerData?.playerPlayheadTime == 0 as NSNumber)
             #expect(firstEvent.playerTextTrackEnabled == false as NSNumber)
             #expect(firstEvent.playerTextTrackName == nil)
             #expect(firstEvent.playerTextTrackType == nil)
@@ -299,7 +298,6 @@ struct TextTrackChangeEventsTests {
             }
 
             let firstEvent = try #require(await iterator.next())
-            #expect(firstEvent.playerData?.playerPlayheadTime == 0 as NSNumber)
             #expect(firstEvent.playerTextTrackEnabled == false as NSNumber)
             #expect(firstEvent.playerTextTrackName == nil)
             #expect(firstEvent.playerTextTrackType == nil)

--- a/Tests/MUXSDKStatsInternalTests/Utilities/Publisher+ExtensionsTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/Utilities/Publisher+ExtensionsTests.swift
@@ -1,0 +1,124 @@
+import Combine
+import Foundation
+import Testing
+@testable import MUXSDKStatsInternal
+
+struct PublisherExtensionsTests {
+
+    // MARK: - Basic Transformation
+
+    @available(iOS 14, tvOS 14, *)
+    @Test func testMapTransformsSingleValue() async throws {
+        try await confirmation(expectedCount: 1) { confirmation in
+            let values = try await collectOutput(
+                from: Just(1).map { value async in
+                    confirmation()
+                    return value * 2
+                }
+            )
+            #expect(values == [2])
+        }
+    }
+
+    @available(iOS 14, tvOS 14, *)
+    @Test func testMapTransformsMultipleValues() async throws {
+        try await confirmation(expectedCount: 3) { confirmation in
+            let values = try await collectOutput(
+                from: [1, 2, 3].publisher.map { value async in
+                    confirmation()
+                    return value * 10
+                }
+            )
+            #expect(values == [10, 20, 30])
+        }
+    }
+
+    @available(iOS 14, tvOS 14, *)
+    @Test func testMapWithAsyncDelayedTransform() async throws {
+        let values = try await collectOutput(
+            from: [1, 2, 3].publisher.map { value async in
+                try? await Task.sleep(nanoseconds: UInt64(NSEC_PER_MSEC * 10))
+                return value + 100
+            }
+        )
+        #expect(values == [101, 102, 103])
+    }
+
+    // MARK: - Type Transformation
+
+    @available(iOS 14, tvOS 14, *)
+    @Test func testMapChangesOutputType() async throws {
+        let values = try await collectOutput(
+            from: Just(42).map { value async in
+                "\(value)"
+            }
+        )
+        #expect(values == ["42"])
+    }
+
+    // MARK: - Ordering
+
+    @available(iOS 14, tvOS 14, *)
+    @Test func testMapPreservesSequentialOrder() async throws {
+        var order: [Int] = []
+        let values = try await collectOutput(
+            from: [1, 2, 3, 4, 5].publisher.map { value async in
+                // Vary delays inversely to ensure ordering
+                // is maintained by serial execution, not speed
+                let delay = UInt64(NSEC_PER_MSEC) * UInt64((6 - value) * 5)
+                try? await Task.sleep(nanoseconds: delay)
+                order.append(value)
+                return value
+            }
+        )
+        #expect(values == [1, 2, 3, 4, 5])
+        #expect(order == [1, 2, 3, 4, 5])
+    }
+
+    // MARK: - Empty Publisher
+
+    @available(iOS 14, tvOS 14, *)
+    @Test func testMapWithEmptyPublisher() async throws {
+        try await confirmation(expectedCount: 0) { confirmation in
+            let values = try await collectOutput(
+                from: Empty<Int, Never>().map { value async in
+                    confirmation()
+                    return "\(value)"
+                }
+            )
+            #expect(values.isEmpty)
+        }
+    }
+
+    // MARK: - Helper
+
+    private func collectOutput<P: Publisher>(
+        from publisher: P,
+        timeout: TimeInterval = 5.0
+    ) async throws -> [P.Output] where P.Failure == Never, P.Output: Sendable {
+        try await withCheckedThrowingContinuation { continuation in
+            var cancellable: AnyCancellable?
+            var values: [P.Output] = []
+            let queue = DispatchQueue(label: "collect output helper", target: .global())
+
+            cancellable = publisher
+                .setFailureType(to: TimeoutError.self)
+                .timeout(.seconds(timeout), scheduler: queue, customError: { TimeoutError() })
+                .sink(
+                    receiveCompletion: { completion in
+                        switch completion {
+                        case .finished:
+                            continuation.resume(returning: values)
+                        case .failure(let failure):
+                            continuation.resume(throwing: failure)
+                        }
+                        _ = cancellable
+                        _ = queue
+                    },
+                    receiveValue: { value in
+                        values.append(value)
+                    }
+                )
+        }
+    }
+}

--- a/scripts/build-pod.sh
+++ b/scripts/build-pod.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Keep this at "~> X.Y" to match the behavior of the "from:" requirement in Package.swift
-readonly MUXCORE_VERSION="~> 5.11"
+readonly MUXCORE_VERSION="~> 5.12"
 
 readonly CODE_SIGNING_IDENTITY="Apple Distribution: Mux, Inc (XX95P4Y787)"
 


### PR DESCRIPTION
Implements `texttrackchange` events (`MUXSDKTextTrackChangeEvent`) using a combination of `AVPlayer.tracks` and `AVMediaSelection` APIs.

This is the release merge PR for a previously-approved feature branch.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New playback telemetry on the shared PlayerMonitor path and async AVFoundation loading could miss or mis-attribute format in edge cases; MuxCore minor bump adds dependency coupling.
> 
> **Overview**
> Adds **`texttrackchange`** analytics by observing legible **AVMediaSelection** (including `mediaSelectionDidChangeNotification`) and, when possible, matching **AVAssetTrack** format info to populate type, format, name, and language on **`MUXSDKTextTrackChangeEvent`**. Events are debounced and deduplicated to collapse noisy intermediate selection states.
> 
> **`PlayerMonitor`** now forwards the new publisher alongside rendition events. **`tracksReadyToPlayPublisher`** is generalized to **`readyToPlayPublisher`** (emits the ready **AVPlayerItem**); rendition timing still loads tracks via a follow-on **`flatMap`**. Supporting pieces include async **Combine** `map`, playback-event timing helpers, and AVFoundation selection/metadata loaders.
> 
> **MuxCore** / **`stats-sdk-objc`** is bumped to **5.12.0** in **Package.swift** and **`build-pod.sh`**, with integration tests against Apple’s bipbop HLS sample.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e653e4a2d9e5e50f70aceafd1fd6d9d127a196af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->