### PR TITLE
Remove flaky timing test

### DIFF
--- a/Tests/MUXSDKStatsInternalTests/Task+TimeoutTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/Task+TimeoutTests.swift
@@ -65,13 +65,6 @@ struct TaskTimeoutTests {
         }
     }
 
-    @Test func testTimeoutDoesNotFireCooperative() async throws {
-        try await withTimeout(seconds: 0.25) {
-            try await Task.sleep(nanoseconds: UInt64(NSEC_PER_MSEC * 25))
-            #expect(!Task.isCancelled, "operation should not be cancelled ")
-        }
-    }
-
     @Test func testTimeoutDoesNotFireNonBlocking() async throws {
         try await withTimeout(seconds: 0.25) {
             await withCheckedContinuation { continuation in


### PR DESCRIPTION
This one often fails because `Task.sleep(nanoseconds: ...)` basically specifies a _minimum_ time to wait. On top of that, it's relying on the same scheduler that's also running all these tests in parallel.

The actual behavior here is already covered by `testTimeoutDoesNotFireNonBlocking()`, which relies on precise deadline-based timing from Dispatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deletion with no production or timeout implementation changes; remaining tests still cover the same behavior.
> 
> **Overview**
> Removes **`testTimeoutDoesNotFireCooperative`** from `Task+TimeoutTests.swift`, which asserted that `withTimeout` does not cancel work that finishes quickly via cooperative `Task.sleep`.
> 
> That case was flaky under parallel test runs because `Task.sleep` only guarantees a minimum delay and competes with the same scheduler. The “short operation completes before timeout” behavior is still exercised by **`testTimeoutDoesNotFireNonBlocking`** (Dispatch deadline timing) and the other remaining timeout tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d251d442cdbfde63bebaa6638a7d14478c3547d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->