### PR TITLE
NAT-443: Enable alternate MuxCore dependency

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,6 +14,7 @@ steps:
       - ".build/artifacts/Package.resolved"
   - label: ":cocoapods: Build for CocoaPods"
     command: "./scripts/build-pod.sh"
+    branches: "releases/*"
     artifact_paths:
       - ".build/artifacts/Cocoapods-Mux-Stats-AVPlayer.zip"
       - ".build/artifacts/Mux-Stats-AVPlayer.podspec"

--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,8 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            name: "stats-sdk-objc",
-            url: "git@github.com:muxinc/mux-stats-sdk-objc.git",
-            branch: "master"),
+            url: "https://github.com/muxinc/stats-sdk-objc.git",
+            from: "5.11.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,9 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/muxinc/stats-sdk-objc.git",
-            from: "5.11.0"),
+            name: "stats-sdk-objc",
+            url: "git@github.com:muxinc/mux-stats-sdk-objc.git",
+            branch: "master"),
     ],
     targets: [
         .target(

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -41,7 +41,8 @@ function merge_and_export_result_bundles {
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -scmProvider system
+    xcodebuild -resolvePackageDependencies \
+        -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/build-package.sh
+++ b/scripts/build-package.sh
@@ -41,7 +41,7 @@ function merge_and_export_result_bundles {
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies
+    xcodebuild -resolvePackageDependencies -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }
@@ -65,7 +65,6 @@ function build_for {
         -disableAutomaticPackageResolution \
         -derivedDataPath "$DERIVED_DATA_PATH" \
         GCC_TREAT_WARNINGS_AS_ERRORS=YES \
-        SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
         RUN_CLANG_STATIC_ANALYZER=YES \
         CLANG_STATIC_ANALYZER_MODE=deep \
         | xcbeautify

--- a/scripts/build-pod.sh
+++ b/scripts/build-pod.sh
@@ -56,7 +56,7 @@ function merge_and_export_result_bundles {
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -project "$PROJECT"
+    xcodebuild -resolvePackageDependencies -scmProvider system -project "$PROJECT"
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/build-pod.sh
+++ b/scripts/build-pod.sh
@@ -56,7 +56,9 @@ function merge_and_export_result_bundles {
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -scmProvider system -project "$PROJECT"
+    xcodebuild -resolvePackageDependencies \
+        -project "$PROJECT" \
+        -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -31,7 +31,10 @@ fi
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -scmProvider system -workspace "$WORKSPACE_PATH" -scheme "$SCHEME"
+    xcodebuild -resolvePackageDependencies \
+        -workspace "$WORKSPACE_PATH" \
+        -scheme "$SCHEME" \
+        -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/run-ci-tests.sh
+++ b/scripts/run-ci-tests.sh
@@ -31,7 +31,7 @@ fi
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -workspace "$WORKSPACE_PATH" -scheme "$SCHEME"
+    xcodebuild -resolvePackageDependencies -scmProvider system -workspace "$WORKSPACE_PATH" -scheme "$SCHEME"
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -47,7 +47,7 @@ function merge_and_export_result_bundles {
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -workspace "$WORKSPACE_PATH" -scheme "$SCHEME"
+    xcodebuild -resolvePackageDependencies -scmProvider system -workspace "$WORKSPACE_PATH" -scheme "$SCHEME"
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -47,7 +47,10 @@ function merge_and_export_result_bundles {
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -scmProvider system -workspace "$WORKSPACE_PATH" -scheme "$SCHEME"
+    xcodebuild -resolvePackageDependencies \
+        -workspace "$WORKSPACE_PATH" \
+        -scheme "$SCHEME" \
+        -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/run-tests-swift-package-manager-ventura.sh
+++ b/scripts/run-tests-swift-package-manager-ventura.sh
@@ -22,7 +22,7 @@ function resolve_packages {
     echo "--- Resolving package dependencies"
 
     xcodebuild -resolvePackageDependencies \
-        -project "MUXSDKStatsExampleSPM.xcodeproj" \
+        -project "$PROJECT" \
         -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
@@ -48,8 +48,8 @@ echo "▸ Testing SDK on iOS Simulator - iPhone 16 Pro"
 resolve_packages
 
 xcodebuild clean build-for-testing \
-    -project MUXSDKStatsExampleSPM.xcodeproj \
-    -scheme "MUXSDKStatsExampleSPM" \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
     -destination 'generic/platform=iOS Simulator' \
     -derivedDataPath "$DERIVED_DATA_PATH" \
     -allowProvisioningUpdates \
@@ -61,8 +61,8 @@ if [ "${1:-}" == 'build-only' ]; then
 fi
 
 xcodebuild test-without-building \
-    -project MUXSDKStatsExampleSPM.xcodeproj \
-    -scheme "MUXSDKStatsExampleSPM" \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
     -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
     -derivedDataPath "$DERIVED_DATA_PATH" \
     | xcbeautify

--- a/scripts/run-tests-swift-package-manager-ventura.sh
+++ b/scripts/run-tests-swift-package-manager-ventura.sh
@@ -21,7 +21,9 @@ mkdir -p "$BUILD_DIR" "$ARTIFACTS_DIR"
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -scmProvider system -project "MUXSDKStatsExampleSPM.xcodeproj"
+    xcodebuild -resolvePackageDependencies \
+        -project "MUXSDKStatsExampleSPM.xcodeproj" \
+        -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/run-tests-swift-package-manager-ventura.sh
+++ b/scripts/run-tests-swift-package-manager-ventura.sh
@@ -21,7 +21,7 @@ mkdir -p "$BUILD_DIR" "$ARTIFACTS_DIR"
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -project "MUXSDKStatsExampleSPM.xcodeproj"
+    xcodebuild -resolvePackageDependencies -scmProvider system -project "MUXSDKStatsExampleSPM.xcodeproj"
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/unit-test-package.sh
+++ b/scripts/unit-test-package.sh
@@ -41,7 +41,7 @@ function merge_and_export_result_bundles {
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies
+    xcodebuild -resolvePackageDependencies -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }

--- a/scripts/unit-test-package.sh
+++ b/scripts/unit-test-package.sh
@@ -41,7 +41,8 @@ function merge_and_export_result_bundles {
 function resolve_packages {
     echo "--- Resolving package dependencies"
 
-    xcodebuild -resolvePackageDependencies -scmProvider system
+    xcodebuild -resolvePackageDependencies \
+        -scmProvider system
 
     cp -ac "$PACKAGE_RESOLVED_FILE" "$ARTIFACTS_DIR"
 }


### PR DESCRIPTION
Minor build script updates centered around convenient feature branch development across this and MuxCore.

Resolves [NAT-443].

[NAT-443]: https://mux1.atlassian.net/browse/NAT-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect CI/build scripts and warning strictness only, not runtime SDK behavior or security-sensitive paths.
> 
> **Overview**
> CI and local Xcode scripts now resolve Swift packages with **`-scmProvider system`**, so dependency resolution can follow system Git (supporting alternate **MuxCore** branches/repos during cross-repo feature work). The same flag is applied across package build/test, pod build, integration/CI tests, and the SPM example script.
> 
> **Buildkite** runs the CocoaPods build step only on **`releases/*`** branches. **`build-package.sh`** no longer treats Swift warnings as errors (`SWIFT_TREAT_WARNINGS_AS_ERRORS` removed). The Ventura SPM example script uses shared **`$PROJECT`** / **`$SCHEME`** variables instead of hard-coded project/scheme names in `xcodebuild` invocations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d8ad1cdcfafb1c053738cc1603bda5e83f5f34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->