### PR TITLE
Support new default of Xcode 26.5 on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,6 +29,8 @@ steps:
       - ".build/artifacts/Package.resolved"
   - command: "./scripts/run-ci-tests.sh"
     label: ":test_tube: CI Tests"
+    env:
+      DEVELOPER_DIR: "/Applications/Xcode_26.2.app"
     artifact_paths:
       - ".build/artifacts/Package.resolved"
   - wait

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -135,7 +135,7 @@ function test_for {
 resolve_packages
 
 test_for 'iOS'
-test_for 'iOS Simulator' 'iPhone 16 Pro'
+test_for 'iOS Simulator' 'iPhone 17 Pro'
 test_for 'macOS,variant=Mac Catalyst'
 test_for 'tvOS'
 test_for 'tvOS Simulator' 'Apple TV 4K (3rd generation) (at 1080p)'

--- a/scripts/run-tests-swift-package-manager-ventura.sh
+++ b/scripts/run-tests-swift-package-manager-ventura.sh
@@ -43,7 +43,7 @@ xcodebuild -list -json
 echo "▸ Running ${SCHEME} Test when installed using Swift Package Manager"
 echo ""
 
-echo "▸ Testing SDK on iOS Simulator - iPhone 16 Pro"
+echo "▸ Testing SDK on iOS Simulator"
 
 resolve_packages
 
@@ -63,6 +63,6 @@ fi
 xcodebuild test-without-building \
     -project "$PROJECT" \
     -scheme "$SCHEME" \
-    -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+    -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
     -derivedDataPath "$DERIVED_DATA_PATH" \
     | xcbeautify

--- a/scripts/unit-test-package.sh
+++ b/scripts/unit-test-package.sh
@@ -105,7 +105,7 @@ function test_for {
 
 resolve_packages
 
-test_for 'iOS Simulator' 'iPhone 16 Pro'
+test_for 'iOS Simulator' 'iPhone 17 Pro'
 test_for 'macOS,variant=Mac Catalyst' 'My Mac'
 test_for 'tvOS Simulator' 'Apple TV 4K (3rd generation) (at 1080p)'
 test_for 'visionOS Simulator' 'Apple Vision Pro'


### PR DESCRIPTION
Sauce Labs upload step seems to rely on some test packaging behavior which has changed, so this step is pinned to an older version pending that investigation (NAT-444).

The simulator changes are not 100% required, but moving them to the 17 series means these scripts work as-is on a fresh, first-time install of recent Xcode. Older simulators would be left over from previous installs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Buildkite env and test destination strings change; no application or SDK runtime logic is modified.
> 
> **Overview**
> Aligns CI and local test scripts with newer Xcode defaults by targeting the **iPhone 17 Pro** simulator instead of **iPhone 16 Pro** in `run-integration-tests.sh`, `unit-test-package.sh`, and `run-tests-swift-package-manager-ventura.sh`, so runs work on a clean install without leftover older simulators.
> 
> The Buildkite **CI Tests** step sets `DEVELOPER_DIR` to `/Applications/Xcode_26.2.app`, pinning that job to a specific Xcode while the fleet moves to 26.5 (per PR notes, pending Sauce Labs upload investigation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0c9bfab4e6ce537d9e0ad5e6499547d1111484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->