### PR TITLE
NAT-412: Add AVPlayer Audio Track Change Events (#355)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,8 +9,9 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            url: "https://github.com/muxinc/stats-sdk-objc.git",
-            from: "5.12.0"),
+            name: "stats-sdk-objc",
+            url: "git@github.com:muxinc/mux-stats-sdk-objc.git",
+            branch: "feature/nat-416-audio-track-changes"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,8 @@ let package = Package(
     ],
     dependencies: [
         .package(
-            name: "stats-sdk-objc",
-            url: "git@github.com:muxinc/mux-stats-sdk-objc.git",
-            branch: "feature/nat-416-audio-track-changes"),
+            url: "https://github.com/muxinc/stats-sdk-objc.git",
+            from: "5.13.0"),
     ],
     targets: [
         .target(

--- a/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
@@ -1,0 +1,329 @@
+import AudioToolbox
+import AVFoundation
+import Combine
+@preconcurrency import MuxCore
+
+@available(iOS 15, tvOS 15, *)
+extension AudioFormatID {
+    var rfc6381CodecsParameterValue: String? {
+        // Explicit mappings only for common streaming-video audio codecs.
+        // Return nil for anything else rather than guessing.
+        switch self {
+        case kAudioFormatAC3:
+            return "ac-3"
+        case kAudioFormatEnhancedAC3:
+            return "ec-3"
+        case kAudioFormatMPEG4AAC:
+            return "mp4a.40.2"
+        case kAudioFormatMPEG4AAC_HE:
+            return "mp4a.40.5"
+        case kAudioFormatMPEG4AAC_HE_V2:
+            return "mp4a.40.29"
+        case kAudioFormatMPEGD_USAC:
+            return "mp4a.40.42"
+        case kAudioFormatOpus:
+            return "opus"
+        default:
+            return nil
+        }
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension MUXSDKAudioTrackChannelLayout {
+    init?(audioFormatDescription: CMAudioFormatDescription) {
+        var channelLayoutSize = 0
+        if let channelLayout = CMAudioFormatDescriptionGetChannelLayout(
+            audioFormatDescription,
+            sizeOut: &channelLayoutSize
+        ), channelLayout.pointee.mChannelLayoutTag.isAtmos {
+            self = .atmos
+            return
+        }
+
+        guard let audioFormat = CMAudioFormatDescriptionGetRichestDecodableFormat(audioFormatDescription)
+            ?? CMAudioFormatDescriptionGetMostCompatibleFormat(audioFormatDescription) else {
+            return nil
+        }
+
+        self.init(
+            channelCount: Int(audioFormat.pointee.mASBD.mChannelsPerFrame),
+            audioChannelLayoutTag: nil
+        )
+    }
+
+    init?(channelCount: Int, audioChannelLayoutTag: AudioChannelLayoutTag?) {
+        if let audioChannelLayoutTag, audioChannelLayoutTag.isAtmos {
+            self = .atmos
+            return
+        }
+
+        switch channelCount {
+        case 1:
+            self = .mono
+        case 2:
+            self = .stereo
+        case 6:
+            self = .fivePointOne
+        case 8:
+            self = .sevenPointOne
+        case let count where count > 0:
+            self = .init("\(count)")
+        default:
+            return nil
+        }
+    }
+}
+
+private extension AudioChannelLayoutTag {
+    var isAtmos: Bool {
+        switch self {
+        case kAudioChannelLayoutTag_Atmos_5_1_2,
+             kAudioChannelLayoutTag_Atmos_5_1_4,
+             kAudioChannelLayoutTag_Atmos_7_1_2,
+             kAudioChannelLayoutTag_Atmos_7_1_4,
+             kAudioChannelLayoutTag_Atmos_9_1_6:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+struct AudioTrackChangeEvents {
+
+    struct AudioTrackInfo: Equatable, Hashable, Sendable {
+        let name: String
+        let language: String?
+        let codec: String?
+        let bitrate: Int?
+        let channels: MUXSDKAudioTrackChannelLayout?
+
+        init(
+            name: String,
+            language: String?,
+            codec: String?,
+            bitrate: Int?,
+            channels: MUXSDKAudioTrackChannelLayout?
+        ) {
+            self.name = name
+            self.language = language
+            self.codec = codec
+            self.bitrate = bitrate
+            self.channels = channels
+        }
+
+        @MainActor
+        init?(_ playerItem: AVPlayerItem) async {
+            guard let mediaSelectionOption = await playerItem.currentMediaSelection.selectedMediaOptionInGroup(for: .audible) else {
+                return nil
+            }
+
+            if let hlsName = await mediaSelectionOption.loadHLSNameAttributeValue() {
+                name = hlsName
+            } else if let title = await mediaSelectionOption.loadTitle() {
+                name = title
+            } else {
+                // This will be in the user's locale, so it is lowest preference.
+                name = mediaSelectionOption.displayName
+            }
+
+            language = mediaSelectionOption.extendedLanguageTag
+
+            let assetTrackInfo: AssetTrackInfo?
+            if let assetTrack = await Self.selectedAudioAssetTrack(on: playerItem, language: language) {
+                assetTrackInfo = await AssetTrackInfo(assetTrack)
+            } else {
+                assetTrackInfo = nil
+            }
+
+            codec = assetTrackInfo?.codec
+            bitrate = assetTrackInfo?.bitrate
+            channels = assetTrackInfo?.channels
+        }
+
+        @MainActor
+        private static func selectedAudioAssetTrack(on playerItem: AVPlayerItem, language: String?) async -> AVAssetTrack? {
+            let enabledAudioTracks = playerItem.tracks.compactMap { (track: AVPlayerItemTrack) -> AVAssetTrack? in
+                guard track.isEnabled,
+                      let assetTrack = track.assetTrack,
+                      assetTrack.mediaType == .audio else {
+                    return nil
+                }
+                return assetTrack
+            }
+
+            switch enabledAudioTracks.count {
+            case 0:
+                return nil
+            case 1:
+                return enabledAudioTracks.first
+            default:
+                guard let language else {
+                    return nil
+                }
+
+                var matchingTracks = [AVAssetTrack]()
+                for assetTrack in enabledAudioTracks {
+                    if assetTrack.extendedLanguageTag == language {
+                        matchingTracks.append(assetTrack)
+                    }
+                }
+
+                return matchingTracks.count == 1 ? matchingTracks.first : nil
+            }
+        }
+    }
+
+    struct AssetTrackInfo: Equatable, Hashable, Sendable {
+        let codec: String?
+        let bitrate: Int?
+        let channels: MUXSDKAudioTrackChannelLayout?
+
+        @MainActor
+        init?(_ assetTrack: AVAssetTrack) async {
+            let formatDescriptions: [CMFormatDescription]
+            let estimatedDataRate: Float
+            do {
+                (formatDescriptions, estimatedDataRate) = try await assetTrack.load(
+                    .formatDescriptions,
+                    .estimatedDataRate)
+            } catch {
+                logger.debug("Failed to load audio track metadata on \(assetTrack): \(error)")
+                return nil
+            }
+
+            let audioFormatDescriptions = formatDescriptions.filter { $0.mediaType == .audio }
+            codec = Self.uniqueValue(audioFormatDescriptions.compactMap(Self.codecString(for:)))
+
+            if estimatedDataRate > 0 {
+                bitrate = Int(estimatedDataRate.rounded())
+            } else {
+                bitrate = nil
+            }
+
+            channels = Self.uniqueValue(audioFormatDescriptions.compactMap(Self.channelLayout(for:)))
+        }
+
+        static func codecString(for formatDescription: CMFormatDescription) -> String? {
+            guard formatDescription.mediaType == .audio else {
+                return nil
+            }
+
+            return formatDescription.mediaSubType.rawValue.rfc6381CodecsParameterValue
+        }
+
+        static func codecString(for formatID: AudioFormatID) -> String? {
+            formatID.rfc6381CodecsParameterValue
+        }
+
+        static func channelLayout(for formatDescription: CMFormatDescription) -> MUXSDKAudioTrackChannelLayout? {
+            guard formatDescription.mediaType == .audio else {
+                return nil
+            }
+
+            return .init(audioFormatDescription: formatDescription as CMAudioFormatDescription)
+        }
+
+        static func channelLayout(
+            channelCount: Int,
+            audioChannelLayoutTag: AudioChannelLayoutTag?
+        ) -> MUXSDKAudioTrackChannelLayout? {
+            .init(channelCount: channelCount, audioChannelLayoutTag: audioChannelLayoutTag)
+        }
+
+        private static func uniqueValue<T: Hashable>(_ values: [T]) -> T? {
+            let uniqueValues = Set(values)
+            guard uniqueValues.count == 1 else {
+                return nil
+            }
+            return uniqueValues.first
+        }
+    }
+
+    let playerItem: AVPlayerItem
+    let minimumIntervalBetweenEvents: TimeInterval
+
+    init(playerItem: AVPlayerItem, minimumIntervalBetweenEvents: TimeInterval = 0.25) {
+        self.playerItem = playerItem
+        self.minimumIntervalBetweenEvents = minimumIntervalBetweenEvents
+    }
+
+    func allEvents() -> some Publisher<MUXSDKAudioTrackChangeEvent, Never> {
+        playerItem.readyToPlayPublisher
+            .catch { _ in
+                // Ignore status failed error.
+                return Empty<AVPlayerItem, Never>()
+            }
+            .flatMap { playerItem in
+                let captureAudioTrackInfo = {
+                    Future(priority: .userInitiated) { @MainActor in
+                        async let timing = await playerItem.currentTiming()
+                        let trackInfo = await AudioTrackInfo(playerItem)
+
+                        return (
+                            timing: await timing,
+                            trackInfo: trackInfo
+                        )
+                    }
+                }
+
+                let audioTrackChanges = NotificationCenter.default
+                    .publisher(
+                        for: AVPlayerItem.mediaSelectionDidChangeNotification,
+                        object: playerItem)
+                    .flatMap { _ in captureAudioTrackInfo() }
+
+                let audioTrackPublisher = Publishers.Concatenate(
+                    prefix: captureAudioTrackInfo(),
+                    suffix: audioTrackChanges)
+                    // This can be a very noisy event stream, with intermediate states
+                    // reported for fractions of a second.
+                    .debounce(for: .seconds(minimumIntervalBetweenEvents), scheduler: DispatchQueue.global())
+                    .removeDuplicates { a, b in
+                        a.trackInfo == b.trackInfo
+                    }
+
+                return audioTrackPublisher
+                    .map { trackInfoAndTiming in
+                        MUXSDKAudioTrackChangeEvent(
+                            timing: trackInfoAndTiming.timing,
+                            trackInfo: trackInfoAndTiming.trackInfo)
+                    }
+            }
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension AVPlayerItem {
+    nonisolated func audioTrackChangeEvents() -> some Publisher<MUXSDKAudioTrackChangeEvent, Never> {
+        AudioTrackChangeEvents(playerItem: self).allEvents()
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension MUXSDKAudioTrackChangeEvent {
+    convenience init(timing: PlaybackEventTiming,
+                     trackInfo: AudioTrackChangeEvents.AudioTrackInfo?) {
+        if let trackInfo {
+            self.init(
+                audioTrackEnabled: true as NSNumber,
+                audioTrackName: trackInfo.name,
+                audioTrackLanguage: trackInfo.language,
+                audioTrackCodec: trackInfo.codec,
+                audioTrackBitrate: trackInfo.bitrate as NSNumber?,
+                audioTrackChannels: trackInfo.channels)
+        } else {
+            self.init(
+                audioTrackEnabled: false as NSNumber,
+                audioTrackName: nil,
+                audioTrackLanguage: nil,
+                audioTrackCodec: nil,
+                audioTrackBitrate: nil,
+                audioTrackChannels: nil)
+        }
+
+        updateWithTiming(timing)
+    }
+}

--- a/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
@@ -273,7 +273,7 @@ struct AudioTrackChangeEvents {
                     .publisher(
                         for: AVPlayerItem.mediaSelectionDidChangeNotification,
                         object: playerItem)
-                    .flatMap { _ in captureAudioTrackInfo() }
+                    .flatMap(maxPublishers: .max(1)) { _ in captureAudioTrackInfo() }
 
                 let audioTrackPublisher = Publishers.Concatenate(
                     prefix: captureAudioTrackInfo(),

--- a/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
@@ -273,7 +273,8 @@ struct AudioTrackChangeEvents {
                     .publisher(
                         for: AVPlayerItem.mediaSelectionDidChangeNotification,
                         object: playerItem)
-                    .flatMap(maxPublishers: .max(1)) { _ in captureAudioTrackInfo() }
+                    .map { _ in captureAudioTrackInfo() }
+                    .switchToLatest()
 
                 let audioTrackPublisher = Publishers.Concatenate(
                     prefix: captureAudioTrackInfo(),

--- a/Sources/MUXSDKStatsInternal/Features/TextTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/TextTrackChangeEvents.swift
@@ -142,7 +142,8 @@ struct TextTrackChangeEvents {
                     .publisher(
                         for: AVPlayerItem.mediaSelectionDidChangeNotification,
                         object: playerItem)
-                    .flatMap(maxPublishers: .max(1)) { _ in captureMediaSelectionOption() }
+                    .map { _ in captureMediaSelectionOption() }
+                    .switchToLatest()
 
                 let mediaSelectionOptionPublisher = Publishers.Concatenate(
                     prefix: captureMediaSelectionOption(),

--- a/Sources/MUXSDKStatsInternal/Features/TextTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/TextTrackChangeEvents.swift
@@ -142,7 +142,7 @@ struct TextTrackChangeEvents {
                     .publisher(
                         for: AVPlayerItem.mediaSelectionDidChangeNotification,
                         object: playerItem)
-                    .flatMap { _ in captureMediaSelectionOption() }
+                    .flatMap(maxPublishers: .max(1)) { _ in captureMediaSelectionOption() }
 
                 let mediaSelectionOptionPublisher = Publishers.Concatenate(
                     prefix: captureMediaSelectionOption(),

--- a/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
+++ b/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
@@ -41,6 +41,12 @@ extension PlayerMonitor {
             .sink(receiveValue: allEventsSubject.send)
             .store(in: &cancellables)
 
+        currentItemPublisher
+            .map { $0?.audioTrackChangeEvents().eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher() }
+            .switchToLatest()
+            .sink(receiveValue: allEventsSubject.send)
+            .store(in: &cancellables)
+
 #if !targetEnvironment(simulator)
         if #available(iOS 18.0, tvOS 18.0, visionOS 2.0, *) {
             currentItemPublisher

--- a/Tests/MUXSDKStatsInternalTests/AudioTrackChangeEventsTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/AudioTrackChangeEventsTests.swift
@@ -1,0 +1,163 @@
+@preconcurrency import AVFoundation
+import AudioToolbox
+import CoreMedia
+@preconcurrency import MuxCore
+@testable import MUXSDKStatsInternal
+import Testing
+
+private let multiAudioTestStreamURL = URL(string: "https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8")!
+private let describesVideoCharacteristic = AVMediaCharacteristic("public.accessibility.describes-video")
+
+@available(iOS 15, tvOS 15, *)
+@MainActor
+private func waitForTrackInfo(
+    on playerItem: AVPlayerItem,
+    named expectedName: String,
+    timeout: TimeInterval = 30
+) async throws -> AudioTrackChangeEvents.AudioTrackInfo {
+    let timeoutDate = Date().addingTimeInterval(timeout)
+
+    while Date() < timeoutDate {
+        if let trackInfo = await AudioTrackChangeEvents.AudioTrackInfo(playerItem),
+           trackInfo.name == expectedName {
+            return trackInfo
+        }
+
+        try await Task.sleep(nanoseconds: 100_000_000)
+    }
+
+    throw TimeoutError()
+}
+
+struct AudioTrackChangeEventsTests {
+    @Test(arguments: [
+        (1, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout.mono),
+        (2, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout.stereo),
+        (6, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout.fivePointOne),
+        (8, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout.sevenPointOne),
+        (3, AudioChannelLayoutTag?.none, MUXSDKAudioTrackChannelLayout("3")),
+        (2, kAudioChannelLayoutTag_Atmos_5_1_2, MUXSDKAudioTrackChannelLayout.atmos),
+    ])
+    func channelLayoutMapping(
+        channelCount: Int,
+        layoutTag: AudioChannelLayoutTag?,
+        expected: MUXSDKAudioTrackChannelLayout?
+    ) {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        #expect(
+            AudioTrackChangeEvents.AssetTrackInfo.channelLayout(
+                channelCount: channelCount,
+                audioChannelLayoutTag: layoutTag
+            ) == expected
+        )
+    }
+
+    @Test(arguments: [
+        (AudioFormatID(kAudioFormatAC3), "ac-3"),
+        (AudioFormatID(kAudioFormatEnhancedAC3), "ec-3"),
+        (AudioFormatID(kAudioFormatMPEG4AAC), "mp4a.40.2"),
+        (AudioFormatID(kAudioFormatMPEG4AAC_HE), "mp4a.40.5"),
+        (AudioFormatID(kAudioFormatMPEG4AAC_HE_V2), "mp4a.40.29"),
+        (AudioFormatID(kAudioFormatMPEGD_USAC), "mp4a.40.42"),
+        (AudioFormatID(kAudioFormatOpus), "opus"),
+        (AudioFormatID(kAudioFormatAppleLossless), nil),
+    ])
+    func codecMapping(formatID: AudioFormatID, expected: String?) {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        #expect(AudioTrackChangeEvents.AssetTrackInfo.codecString(for: formatID) == expected)
+    }
+
+    @Test
+    func disabledEventOmitsOptionalMetadata() throws {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let event = MUXSDKAudioTrackChangeEvent(
+            timing: PlaybackEventTiming(
+                mediaTime: .zero,
+                programDate: nil,
+                liveEdgeProgramDate: nil),
+            trackInfo: nil)
+
+        let playerData = try #require(event.playerData)
+
+        #expect(event.playerAudioTrackEnabled as? Bool == false)
+        #expect(event.playerAudioTrackName == nil)
+        #expect(event.playerAudioTrackLanguage == nil)
+        #expect(event.playerAudioTrackCodec == nil)
+        #expect(event.playerAudioTrackBitrate == nil)
+        #expect(event.playerAudioTrackChannels == nil)
+        #expect(playerData.playerAudioTrackEnabled as? Bool == false)
+    }
+
+    @Test
+    func selectedEventPreservesAllExtractedMetadata() throws {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let event = MUXSDKAudioTrackChangeEvent(
+            audioTrackEnabled: true as NSNumber,
+            audioTrackName: "English",
+            audioTrackLanguage: "en-US",
+            audioTrackCodec: "ec-3",
+            audioTrackBitrate: 128_000,
+            audioTrackChannels: MUXSDKAudioTrackChannelLayout.stereo)
+
+        event.updateWithTiming(
+            PlaybackEventTiming(
+                mediaTime: CMTime(seconds: 12.345, preferredTimescale: 1000),
+                programDate: Date(timeIntervalSince1970: 100),
+                liveEdgeProgramDate: nil))
+
+        let playerData = try #require(event.playerData)
+
+        #expect(event.playerAudioTrackEnabled as? Bool == true)
+        #expect(event.playerAudioTrackName == "English")
+        #expect(event.playerAudioTrackLanguage == "en-US")
+        #expect(event.playerAudioTrackCodec == "ec-3")
+        #expect(event.playerAudioTrackBitrate?.intValue == 128_000)
+        #expect(event.playerAudioTrackChannels == MUXSDKAudioTrackChannelLayout.stereo)
+        #expect(playerData.playerAudioTrackEnabled as? Bool == true)
+        #expect(playerData.playerAudioTrackName == "English")
+        #expect(playerData.playerAudioTrackLanguage == "en-US")
+        #expect(playerData.playerAudioTrackCodec == "ec-3")
+        #expect(playerData.playerAudioTrackBitrate?.intValue == 128_000)
+        #expect(playerData.playerAudioTrackChannels == MUXSDKAudioTrackChannelLayout.stereo)
+        #expect(playerData.playerPlayheadTime?.intValue == 12_345)
+    }
+
+    @MainActor
+    @Test
+    func audibleMediaSelectionChangePublishesUpdatedTrackInfo() async throws {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        let playerItem = AVPlayerItem(url: multiAudioTestStreamURL)
+
+        let initialTrackInfo = try await waitForTrackInfo(on: playerItem, named: "English")
+        #expect(initialTrackInfo.language == "en-US")
+
+        let audibleGroup = try #require(
+            try await playerItem.asset.loadMediaSelectionGroup(for: .audible)
+        )
+        let dvsOption = try #require(audibleGroup.options.first(where: {
+            $0.hasMediaCharacteristic(describesVideoCharacteristic)
+        }))
+
+        await MainActor.run {
+            playerItem.select(dvsOption, in: audibleGroup)
+        }
+
+        let changedTrackInfo = try await waitForTrackInfo(on: playerItem, named: "English (DVS)")
+        #expect(changedTrackInfo.language == "en-US")
+    }
+}


### PR DESCRIPTION
Merge PR for previously-approved feature branch (#355). Keeping in draft until MuxCore API is released.

Resolves [NAT-412].

[NAT-412]: https://mux1.atlassian.net/browse/NAT-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live player event pipeline and adds async AVFoundation metadata loading; behavior is modeled on text-track events but incorrect track matching could mis-report analytics.
> 
> **Overview**
> Adds **audio track change** telemetry for AVPlayer on iOS/tvOS 15+, parallel to existing text-track events. When the audible selection changes (or on first ready-to-play snapshot), the SDK emits `MUXSDKAudioTrackChangeEvent` with enabled state, name, language, RFC6381 codec, bitrate, and channel layout (mono/stereo/5.1/7.1/Atmos or custom counts), with debouncing and duplicate suppression on noisy `mediaSelectionDidChange` updates.
> 
> `PlayerMonitor` now subscribes to `audioTrackChangeEvents()` on the current item so these events flow into the shared event stream. **MuxCore** is bumped to **5.13.0** for the new event types.
> 
> **Text track** media-selection handling is adjusted from `flatMap` to `map` + `switchToLatest()` so in-flight async captures are cancelled correctly when selection changes rapidly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e1310954c3fd20b2c6bb7fbd3d0dd57a4b0c1aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->