### PR TITLE
NAT-458: Fix audio codec profile reporting

### DIFF
--- a/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
@@ -211,6 +211,12 @@ struct AudioTrackChangeEvents {
                 return nil
             }
 
+            let audioFormatDescription = formatDescription as CMAudioFormatDescription
+            if let richestFormat = CMAudioFormatDescriptionGetRichestDecodableFormat(audioFormatDescription),
+               let codecString = codecString(for: richestFormat.pointee.mASBD.mFormatID) {
+                return codecString
+            }
+
             return formatDescription.mediaSubType.rawValue.rfc6381CodecsParameterValue
         }
 

--- a/Tests/MUXSDKStatsInternalTests/AudioTrackChangeEventsTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/AudioTrackChangeEventsTests.swift
@@ -73,6 +73,27 @@ struct AudioTrackChangeEventsTests {
         #expect(AudioTrackChangeEvents.AssetTrackInfo.codecString(for: formatID) == expected)
     }
 
+    @Test(arguments: [
+        (AudioFormatID(kAudioFormatMPEG4AAC), "mp4a.40.2"),
+        (AudioFormatID(kAudioFormatMPEG4AAC_HE), "mp4a.40.5"),
+        (AudioFormatID(kAudioFormatMPEG4AAC_HE_V2), "mp4a.40.29"),
+        (AudioFormatID(kAudioFormatMPEGD_USAC), "mp4a.40.42"),
+        (AudioFormatID(kAudioFormatEnhancedAC3), "ec-3"),
+        (AudioFormatID(kAudioFormatAC3), "ac-3"),
+    ])
+    func codecStringForFormatDescription(formatID: AudioFormatID, expected: String?) throws {
+        guard #available(iOS 15, tvOS 15, *) else {
+            return
+        }
+
+        // Synthetic format descriptions validate this overload and its fallback behavior.
+        // AVFoundation-created HE-AAC descriptions are still needed to exercise mediaSubType
+        // flattening to AAC-LC while the richest decodable format remains HE-AAC.
+        let formatDescription = try audioFormatDescription(formatID: formatID)
+
+        #expect(AudioTrackChangeEvents.AssetTrackInfo.codecString(for: formatDescription) == expected)
+    }
+
     @Test
     func disabledEventOmitsOptionalMetadata() throws {
         guard #available(iOS 15, tvOS 15, *) else {
@@ -160,4 +181,36 @@ struct AudioTrackChangeEventsTests {
         let changedTrackInfo = try await waitForTrackInfo(on: playerItem, named: "English (DVS)")
         #expect(changedTrackInfo.language == "en-US")
     }
+}
+
+@available(iOS 15, tvOS 15, *)
+private func audioFormatDescription(formatID: AudioFormatID) throws -> CMFormatDescription {
+    var asbd = AudioStreamBasicDescription(
+        mSampleRate: 48_000,
+        mFormatID: formatID,
+        mFormatFlags: 0,
+        mBytesPerPacket: 0,
+        mFramesPerPacket: 1024,
+        mBytesPerFrame: 0,
+        mChannelsPerFrame: 2,
+        mBitsPerChannel: 0,
+        mReserved: 0
+    )
+    var formatDescription: CMAudioFormatDescription?
+    let status = CMAudioFormatDescriptionCreate(
+        allocator: kCFAllocatorDefault,
+        asbd: &asbd,
+        layoutSize: 0,
+        layout: nil,
+        magicCookieSize: 0,
+        magicCookie: nil,
+        extensions: nil,
+        formatDescriptionOut: &formatDescription
+    )
+
+    guard status == noErr, let formatDescription else {
+        throw NSError(domain: NSOSStatusErrorDomain, code: Int(status))
+    }
+
+    return formatDescription
 }


### PR DESCRIPTION
## Summary

Fix audio track codec reporting to prefer CoreMedia's richest decodable audio format before falling back to the format description subtype.

This preserves the existing fallback behavior, but lets AAC variants such as HE-AAC and HE-AACv2 report their more specific RFC 6381 codec strings instead of being flattened to AAC-LC.

## Root Cause

`CMFormatDescription.mediaSubType` can expose the most-compatible AAC subtype for HE-AAC/HE-AACv2 tracks, which reports `mp4a.40.2`. The audio format description can also include a richer decodable format, where HE-AACv2 maps to `kAudioFormatMPEG4AAC_HE_V2` / `mp4a.40.29`.

## Validation

- `xcodebuild -scheme MUXSDKStats -destination 'generic/platform=iOS Simulator' build`
- Manual local HE-AACv2 HLS playback verified in the Mux dashboard:
<img width="432" height="234" alt="Screenshot 2026-06-16 at 12 51 52 PM" src="https://github.com/user-attachments/assets/74f18da1-0e99-4b90-abfc-605c78e8736b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only metadata extraction for audio track change events; behavior is additive with an explicit fallback and new unit tests.
> 
> **Overview**
> **Fixes audio track codec strings in Mux stats** so HE-AAC, HE-AACv2, USAC, and similar profiles report their specific RFC 6381 values (e.g. `mp4a.40.29`) instead of being flattened to AAC-LC (`mp4a.40.2`) when `CMFormatDescription.mediaSubType` only exposes the most-compatible subtype.
> 
> `AssetTrackInfo.codecString(for: CMFormatDescription)` now consults **`CMAudioFormatDescriptionGetRichestDecodableFormat`** and maps `mFormatID` through the existing `AudioFormatID` → codec mapping, then **falls back** to the prior `mediaSubType` path when no richer format is available.
> 
> Adds parameterized tests over synthetic audio format descriptions plus a small **`CMAudioFormatDescriptionCreate`** test helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 439dfbe949b1610b1701294cfa22587ace949941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->