### PR TITLE
NAT-456: Automate release artifact publishing (tag-driven)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,3 +48,19 @@ steps:
     branches: "releases/*"
     artifact_paths:
       - ".build/artifacts/Package.resolved"
+  - wait
+  # Release publishing. Runs only on vX.Y.Z tag builds (created automatically
+  # when a releases/vX.Y.Z PR merges). Builds the CocoaPods artifacts and
+  # attaches them to a DRAFT GitHub release for maintainer review. Requires the
+  # agent to provide a GitHub token (GITHUB_TOKEN) with contents:write on this
+  # repo, plus `gh` on PATH. See RELEASING.md.
+  - label: ":rocket: Publish Release Artifacts"
+    if: build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
+    command:
+      - "./scripts/build-pod.sh"
+      - "./scripts/publish-release.sh"
+    artifact_paths:
+      - ".build/artifacts/Cocoapods-Mux-Stats-AVPlayer.zip"
+      - ".build/artifacts/Mux-Stats-AVPlayer.podspec"
+      - ".build/artifacts/*.xcresult.zip"
+      - ".build/artifacts/Package.resolved"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,13 +2,18 @@ agents:
   queue: "macOS-Monterey-12-4"
 
 steps:
+  # Standard CI runs on branches/master (build.tag == null). On a vX.Y.Z tag
+  # build, all of these are skipped and only "Publish Release Artifacts" runs —
+  # the tag commit was already validated on the release branch + master.
   - command: "./scripts/unit-test-package.sh"
     label: ":xcode_simulator: Unit Test Package"
+    if: build.tag == null
     artifact_paths:
       - ".build/artifacts/*.xcresult.zip"
       - ".build/artifacts/Package.resolved"
   - command: "./scripts/build-package.sh"
     label: ":xcode: Build for Swift Package Manager"
+    if: build.tag == null
     artifact_paths:
       - ".build/artifacts/*.xcresult.zip"
       - ".build/artifacts/Package.resolved"
@@ -23,12 +28,14 @@ steps:
   - wait
   - command: "./scripts/run-integration-tests.sh"
     label: ":xcode_simulator: Integration Tests"
+    if: build.tag == null
     artifact_paths:
       - ".build/artifacts/*.xctestproducts.zip"
       - ".build/artifacts/*.xcresult.zip"
       - ".build/artifacts/Package.resolved"
   - command: "./scripts/run-ci-tests.sh"
     label: ":test_tube: CI Tests"
+    if: build.tag == null
     env:
       DEVELOPER_DIR: "/Applications/Xcode_26.2.app"
     artifact_paths:
@@ -40,7 +47,7 @@ steps:
   - wait
   - command: "./scripts/run-tests-swift-package-manager-ventura.sh build-only"
     label: ":swift: Build Swift Package Manager Example"
-    branches: "!releases/*"
+    if: build.branch !~ /^releases\// && build.tag == null
     artifact_paths:
       - ".build/artifacts/Package.resolved"
   - command: "./scripts/run-tests-swift-package-manager-ventura.sh"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,9 +2,7 @@ agents:
   queue: "macOS-Monterey-12-4"
 
 steps:
-  # Standard CI runs on branches/master (build.tag == null). On a vX.Y.Z tag
-  # build, all of these are skipped and only "Publish Release Artifacts" runs —
-  # the tag commit was already validated on the release branch + master.
+  # Standard CI. Skipped on vX.Y.Z tag builds, where only Publish runs.
   - command: "./scripts/unit-test-package.sh"
     label: ":xcode_simulator: Unit Test Package"
     if: build.tag == null
@@ -56,11 +54,7 @@ steps:
     artifact_paths:
       - ".build/artifacts/Package.resolved"
   - wait
-  # Release publishing. Runs only on vX.Y.Z tag builds (created automatically
-  # when a releases/vX.Y.Z PR merges). Builds the CocoaPods artifacts and
-  # attaches them to a DRAFT GitHub release for maintainer review. Requires the
-  # agent to provide a GitHub token (GITHUB_TOKEN) with contents:write on this
-  # repo, plus `gh` on PATH. See RELEASING.md.
+  # Runs only on vX.Y.Z tag builds. Needs `gh` + GITHUB_TOKEN (contents:write) on the agent.
   - label: ":rocket: Publish Release Artifacts"
     if: build.tag =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/
     command:

--- a/.github/workflows/tagged-release-pr.yml
+++ b/.github/workflows/tagged-release-pr.yml
@@ -1,36 +1,65 @@
-name: Draft a new release
+name: Tag and draft a merged release
+
+# When a releases/vX.Y.Z PR merges into master, GitHub owns the "release object"
+# side of the handoff:
+#   - create the vX.Y.Z tag on the merge commit
+#   - create the DRAFT GitHub release (with generated notes) for that tag
+# Buildkite then owns the "binaries" side: it builds the tag and uploads the
+# signed CocoaPods artifacts to this draft release
+# (see .buildkite/pipeline.yml + scripts/publish-release.sh).
+# A maintainer reviews and publishes the draft. SwiftPM resolves from the tag.
 
 on:
   pull_request:
     types: [ closed ]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
-  draft:
-    # Change the quoted text to match your release branch naming convention
+  tag:
+    name: Create the release tag on the merge commit
     if: startsWith(github.head_ref, 'releases/v') && github.event.pull_request.merged
     runs-on: ubuntu-latest
-    name: Create the Release on the destination branch
     steps:
-      - uses: actions/checkout@v3
-      - name: Parse the tag name out of the release branch
+      - name: Derive tag from the release branch
         id: version
-        run: >
-          echo "tag_name="$(echo ${{ github.head_ref }} | grep -E "^release.?[\/-]" | sed -E "s/release.?[\/-]//")"" >> $GITHUB_OUTPUT
-      - name: Create the release
-        id: release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.version.outputs.tag_name }}
-          release_name: ${{ steps.version.outputs.tag_name }}
-          body: ${{ github.event.pull_request.body }}
-          commitish: ${{ github.event.pull_request.merge_commit_sha }}
-          draft: true
-      - uses: mshick/add-pr-comment@v1
-        name: Link the Release to the PR
-        with:
-          message: A draft release has been created for this version. Find it here! ${{ steps.release.outputs.html_url }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          repo-token-user-login: 'github-actions[bot]' # The user.login for temporary GitHub tokens
-          allow-repeats: false
+          HEAD_REF: ${{ github.head_ref }}
+        run: echo "tag=${HEAD_REF#releases/}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push the tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/${REPO}/git/refs" \
+            -f ref="refs/tags/${TAG}" \
+            -f sha="${SHA}"
+          echo "Created tag ${TAG} at ${SHA}"
+
+      - name: Create the draft GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release create "${TAG}" \
+            --repo "${REPO}" \
+            --draft \
+            --verify-tag \
+            --title "${TAG}" \
+            --generate-notes
+          echo "Created draft release ${TAG}"
+
+      - name: Comment on the PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "${PR}" --body \
+            "Tag \`${TAG}\` and a draft release were created on the merge commit. Buildkite will build the tag and attach the CocoaPods artifacts to the draft release for review."

--- a/.github/workflows/tagged-release-pr.yml
+++ b/.github/workflows/tagged-release-pr.yml
@@ -1,13 +1,7 @@
 name: Tag and draft a merged release
 
-# When a releases/vX.Y.Z PR merges into master, GitHub owns the "release object"
-# side of the handoff:
-#   - create the vX.Y.Z tag on the merge commit
-#   - create the DRAFT GitHub release (with generated notes) for that tag
-# Buildkite then owns the "binaries" side: it builds the tag and uploads the
-# signed CocoaPods artifacts to this draft release
-# (see .buildkite/pipeline.yml + scripts/publish-release.sh).
-# A maintainer reviews and publishes the draft. SwiftPM resolves from the tag.
+# On merge of a releases/vX.Y.Z PR, create the vX.Y.Z tag + a draft release.
+# The tag triggers Buildkite to build and attach the CocoaPods artifacts.
 
 on:
   pull_request:

--- a/.github/workflows/tagged-release-pr.yml
+++ b/.github/workflows/tagged-release-pr.yml
@@ -50,8 +50,12 @@ jobs:
           REPO: ${{ github.repository }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          if gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+          state="$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+          if [[ "${state}" == "true" ]]; then
             echo "Draft release ${TAG} already exists; continuing."
+          elif [[ "${state}" == "false" ]]; then
+            echo "Release ${TAG} already exists and is published; refusing to proceed." >&2
+            exit 1
           else
             gh release create "${TAG}" \
               --repo "${REPO}" \

--- a/.github/workflows/tagged-release-pr.yml
+++ b/.github/workflows/tagged-release-pr.yml
@@ -24,30 +24,43 @@ jobs:
         run: echo "tag=${HEAD_REF#releases/}" >> "$GITHUB_OUTPUT"
 
       - name: Create and push the tag
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
           SHA: ${{ github.event.pull_request.merge_commit_sha }}
           REPO: ${{ github.repository }}
         run: |
-          gh api "repos/${REPO}/git/refs" \
-            -f ref="refs/tags/${TAG}" \
-            -f sha="${SHA}"
-          echo "Created tag ${TAG} at ${SHA}"
+          existing="$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.sha' 2>/dev/null || true)"
+          if [[ -z "${existing}" ]]; then
+            gh api "repos/${REPO}/git/refs" -f ref="refs/tags/${TAG}" -f sha="${SHA}"
+            echo "Created tag ${TAG} at ${SHA}"
+          elif [[ "${existing}" == "${SHA}" ]]; then
+            echo "Tag ${TAG} already exists at ${SHA}; continuing."
+          else
+            echo "Tag ${TAG} already exists but points to ${existing}, not ${SHA}." >&2
+            exit 1
+          fi
 
       - name: Create the draft GitHub release
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
           REPO: ${{ github.repository }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          gh release create "${TAG}" \
-            --repo "${REPO}" \
-            --draft \
-            --verify-tag \
-            --title "${TAG}" \
-            --generate-notes
-          echo "Created draft release ${TAG}"
+          if gh release view "${TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+            echo "Draft release ${TAG} already exists; continuing."
+          else
+            gh release create "${TAG}" \
+              --repo "${REPO}" \
+              --draft \
+              --verify-tag \
+              --title "${TAG}" \
+              --notes "${PR_BODY}"
+            echo "Created draft release ${TAG}"
+          fi
 
       - name: Comment on the PR
         env:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,25 @@
+name: Script tests
+
+# Runs the offline test suites for the release scripts on PRs that touch
+# scripts/. No macOS, secrets, or network needed — the tests mock `gh` and use
+# fixtures, so they run on a plain Linux runner in seconds.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/**'
+
+jobs:
+  test:
+    name: Run script test suites
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run scripts/tests
+        run: |
+          status=0
+          for t in scripts/tests/test-*.sh; do
+            echo "== $t =="
+            bash "$t" || status=1
+          done
+          exit $status

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Attach the CocoaPods release artifacts to the GitHub release for the current
+# tag. Intended to run in the Buildkite tag build, immediately after
+# build-pod.sh has produced the artifacts in .build/artifacts.
+#
+# It does NOT download anything from Buildkite and needs no Buildkite API token:
+# the artifacts are already on the agent. It only needs a GitHub token with
+# `contents: write` on this repository (injected by the agent as GITHUB_TOKEN).
+#
+# Division of labour: the GitHub Actions release workflow owns the release object
+# (it creates the tag and the draft release with notes on merge). This script
+# owns the binaries: it verifies and uploads them to that draft.
+#
+# Behaviour:
+#   - verifies the built podspec/zip actually belong to this tag
+#     (version, source URL, and sha256 checksum)
+#   - uploads the zip + podspec to the tag's DRAFT release (idempotent)
+#   - creates the draft as a FALLBACK only if the workflow did not (e.g. a
+#     manually pushed tag, or a re-run after a failed workflow)
+#   - refuses to touch an already-published release
+#
+# A maintainer reviews the draft and publishes it manually.
+
+readonly ZIP_NAME="Cocoapods-Mux-Stats-AVPlayer.zip"
+readonly PODSPEC_NAME="Mux-Stats-AVPlayer.podspec"
+
+function die {
+    echo "$@" >&2
+    exit 1
+}
+
+function require_command {
+    command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+# Extract the sha256 the podspec declares for its source zip (`:sha256 => '...'`).
+function podspec_checksum {
+    awk -F"'" '/:sha256[[:space:]]*=>/ { print $2; exit }' "$1"
+}
+
+require_command gh
+require_command jq
+require_command shasum
+
+# The version is the tag being built. Buildkite sets BUILDKITE_TAG on tag
+# builds; VERSION can override it for local testing.
+VERSION="${VERSION:-${BUILDKITE_TAG:-}}"
+[[ -n "$VERSION" ]] \
+    || die "No version found. Set BUILDKITE_TAG (tag build) or VERSION (local)."
+[[ "$VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || die "VERSION must look like vX.Y.Z or X.Y.Z (got '$VERSION')."
+
+readonly RELEASE_VERSION="${VERSION#v}"
+readonly RELEASE_TAG="v$RELEASE_VERSION"
+readonly GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-muxinc/mux-stats-sdk-avplayer}"
+readonly ARTIFACTS_DIR="${ARTIFACTS_DIR:-.build/artifacts}"
+
+# gh authenticates from GH_TOKEN/GITHUB_TOKEN. The Buildkite agent must inject a
+# GitHub token scoped to contents:write on this repo.
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    export GH_TOKEN="$GITHUB_TOKEN"
+fi
+[[ -n "${GH_TOKEN:-}" ]] \
+    || die "No GitHub token. Set GITHUB_TOKEN (or GH_TOKEN) in the agent environment."
+
+readonly zip_path="$ARTIFACTS_DIR/$ZIP_NAME"
+readonly podspec_path="$ARTIFACTS_DIR/$PODSPEC_NAME"
+
+[[ -f "$zip_path" ]] || die "Missing artifact: $zip_path (did build-pod.sh run?)"
+[[ -f "$podspec_path" ]] || die "Missing artifact: $podspec_path (did build-pod.sh run?)"
+
+# --- Verify the built artifacts actually belong to this tag ---
+grep -q "s.version *= *'$RELEASE_VERSION'" "$podspec_path" \
+    || die "Podspec version does not match $RELEASE_VERSION."
+grep -q "releases/download/$RELEASE_TAG/$ZIP_NAME" "$podspec_path" \
+    || die "Podspec source URL does not point at releases/download/$RELEASE_TAG/$ZIP_NAME."
+
+expected_checksum="$(podspec_checksum "$podspec_path")"
+[[ -n "$expected_checksum" ]] || die "Podspec does not contain a :sha256 source checksum."
+
+actual_checksum="$(shasum -a 256 "$zip_path" | awk '{ print $1 }')"
+[[ "$actual_checksum" == "$expected_checksum" ]] || die "Zip checksum does not match podspec checksum.
+Expected: $expected_checksum
+Actual:   $actual_checksum"
+
+echo "Verified artifacts for $RELEASE_TAG:"
+ls -lh "$zip_path" "$podspec_path"
+
+# --- Find the DRAFT release (normally created by the release workflow) ---
+if release_json="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft 2>/dev/null)"; then
+    [[ "$(echo "$release_json" | jq --raw-output '.isDraft')" == "true" ]] \
+        || die "Release $RELEASE_TAG is already published. Refusing to modify a published release."
+    echo "Using draft release $RELEASE_TAG."
+else
+    # Fallback: the release workflow normally creates this draft on merge. Create
+    # it here so a manually pushed tag or a workflow re-run still works.
+    echo "Draft release $RELEASE_TAG not found; creating it (fallback)."
+    gh release create "$RELEASE_TAG" \
+        --repo "$GITHUB_REPOSITORY" \
+        --draft \
+        --verify-tag \
+        --title "$RELEASE_TAG" \
+        --generate-notes
+fi
+
+# --- Upload the artifacts (idempotent) ---
+gh release upload "$RELEASE_TAG" "$zip_path" "$podspec_path" \
+    --repo "$GITHUB_REPOSITORY" \
+    --clobber
+
+# --- Confirm both assets are attached ---
+assets_json="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets,url)"
+for asset_name in "$ZIP_NAME" "$PODSPEC_NAME"; do
+    echo "$assets_json" | jq --exit-status --arg name "$asset_name" \
+        '.assets[] | select(.name == $name)' >/dev/null \
+        || die "Release $RELEASE_TAG is missing expected asset: $asset_name"
+done
+
+echo "Attached assets to draft release $RELEASE_TAG:"
+echo "$assets_json" | jq --raw-output '.assets[] | " - \(.name)"'
+echo "Draft release: $(echo "$assets_json" | jq --raw-output '.url')"
+echo "Next: review the draft release notes and publish it manually."

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,27 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Attach the CocoaPods release artifacts to the GitHub release for the current
-# tag. Intended to run in the Buildkite tag build, immediately after
-# build-pod.sh has produced the artifacts in .build/artifacts.
-#
-# It does NOT download anything from Buildkite and needs no Buildkite API token:
-# the artifacts are already on the agent. It only needs a GitHub token with
-# `contents: write` on this repository (injected by the agent as GITHUB_TOKEN).
-#
-# Division of labour: the GitHub Actions release workflow owns the release object
-# (it creates the tag and the draft release with notes on merge). This script
-# owns the binaries: it verifies and uploads them to that draft.
-#
-# Behaviour:
-#   - verifies the built podspec/zip actually belong to this tag
-#     (version, source URL, and sha256 checksum)
-#   - uploads the zip + podspec to the tag's DRAFT release (idempotent)
-#   - creates the draft as a FALLBACK only if the workflow did not (e.g. a
-#     manually pushed tag, or a re-run after a failed workflow)
-#   - refuses to touch an already-published release
-#
-# A maintainer reviews the draft and publishes it manually.
+# Verify the CocoaPods artifacts (built by build-pod.sh) and upload them to the
+# tag's draft GitHub release. Runs in the Buildkite tag build.
+# Needs `gh` and a GITHUB_TOKEN with contents:write on this repo (from the agent).
+# The release workflow normally creates the draft; this creates it as a fallback.
 
 readonly ZIP_NAME="Cocoapods-Mux-Stats-AVPlayer.zip"
 readonly PODSPEC_NAME="Mux-Stats-AVPlayer.podspec"
@@ -35,7 +18,7 @@ function require_command {
     command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
 }
 
-# Extract the sha256 the podspec declares for its source zip (`:sha256 => '...'`).
+# sha256 the podspec declares for its source zip (`:sha256 => '...'`).
 function podspec_checksum {
     awk -F"'" '/:sha256[[:space:]]*=>/ { print $2; exit }' "$1"
 }
@@ -44,8 +27,7 @@ require_command gh
 require_command jq
 require_command shasum
 
-# The version is the tag being built. Buildkite sets BUILDKITE_TAG on tag
-# builds; VERSION can override it for local testing.
+# Version = the tag being built (BUILDKITE_TAG); VERSION overrides for local runs.
 VERSION="${VERSION:-${BUILDKITE_TAG:-}}"
 [[ -n "$VERSION" ]] \
     || die "No version found. Set BUILDKITE_TAG (tag build) or VERSION (local)."
@@ -57,8 +39,6 @@ readonly RELEASE_TAG="v$RELEASE_VERSION"
 readonly GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-muxinc/mux-stats-sdk-avplayer}"
 readonly ARTIFACTS_DIR="${ARTIFACTS_DIR:-.build/artifacts}"
 
-# gh authenticates from GH_TOKEN/GITHUB_TOKEN. The Buildkite agent must inject a
-# GitHub token scoped to contents:write on this repo.
 if [[ -n "${GITHUB_TOKEN:-}" ]]; then
     export GH_TOKEN="$GITHUB_TOKEN"
 fi
@@ -71,7 +51,6 @@ readonly podspec_path="$ARTIFACTS_DIR/$PODSPEC_NAME"
 [[ -f "$zip_path" ]] || die "Missing artifact: $zip_path (did build-pod.sh run?)"
 [[ -f "$podspec_path" ]] || die "Missing artifact: $podspec_path (did build-pod.sh run?)"
 
-# --- Verify the built artifacts actually belong to this tag ---
 grep -q "s.version *= *'$RELEASE_VERSION'" "$podspec_path" \
     || die "Podspec version does not match $RELEASE_VERSION."
 grep -q "releases/download/$RELEASE_TAG/$ZIP_NAME" "$podspec_path" \
@@ -88,14 +67,13 @@ Actual:   $actual_checksum"
 echo "Verified artifacts for $RELEASE_TAG:"
 ls -lh "$zip_path" "$podspec_path"
 
-# --- Find the DRAFT release (normally created by the release workflow) ---
 if release_json="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft 2>/dev/null)"; then
     [[ "$(echo "$release_json" | jq --raw-output '.isDraft')" == "true" ]] \
         || die "Release $RELEASE_TAG is already published. Refusing to modify a published release."
     echo "Using draft release $RELEASE_TAG."
 else
-    # Fallback: the release workflow normally creates this draft on merge. Create
-    # it here so a manually pushed tag or a workflow re-run still works.
+    # Fallback: normally the release workflow creates the draft; create it here
+    # for a manually pushed tag or a workflow re-run.
     echo "Draft release $RELEASE_TAG not found; creating it (fallback)."
     gh release create "$RELEASE_TAG" \
         --repo "$GITHUB_REPOSITORY" \
@@ -105,12 +83,10 @@ else
         --generate-notes
 fi
 
-# --- Upload the artifacts (idempotent) ---
 gh release upload "$RELEASE_TAG" "$zip_path" "$podspec_path" \
     --repo "$GITHUB_REPOSITORY" \
     --clobber
 
-# --- Confirm both assets are attached ---
 assets_json="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets,url)"
 for asset_name in "$ZIP_NAME" "$PODSPEC_NAME"; do
     echo "$assets_json" | jq --exit-status --arg name "$asset_name" \

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# set-version.sh — Set a new release version across the codebase.
+#
+# Usage:
+#   scripts/set-version.sh X.Y.Z
+#
+# Mirrors scripts/set-version.sh in the other Mux iOS SDK repos so the release
+# step is the same command everywhere. Here it updates the two files that
+# hardcode the SDK version:
+#   - scripts/MUXSDKStatsFramework.xcconfig        -> MARKETING_VERSION
+#   - Sources/MUXSDKStats/MUXSDKPlayerBinding.m    -> MUXSDKPluginVersion
+#
+# It deliberately does NOT touch the MuxCore dependency version (Package.swift /
+# MUXCORE_VERSION) — that is a separate dependency on its own cadence.
+set -euo pipefail
+IFS=$'\n\t'
+
+# --- Locate the repository root relative to this script -----------------------
+# Resolve regardless of the caller's current working directory. REPO_ROOT can be
+# overridden (used by the tests).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+readonly SCRIPT_DIR REPO_ROOT
+
+readonly XCCONFIG="${REPO_ROOT}/scripts/MUXSDKStatsFramework.xcconfig"
+readonly BINDING="${REPO_ROOT}/Sources/MUXSDKStats/MUXSDKPlayerBinding.m"
+
+# Temp file used by update_file; cleaned up on exit if a run is interrupted.
+TMP_FILE=""
+cleanup() {
+  if [[ -n "$TMP_FILE" ]]; then
+    rm -f "$TMP_FILE"
+  fi
+}
+trap cleanup EXIT
+
+usage() {
+  cat >&2 <<EOF
+Usage: ${0##*/} <version>
+
+Set a new release version (X.Y.Z) across the xcconfig and the plugin binding.
+
+Arguments:
+  version   New semantic version, e.g. 4.15.0 (a leading "v" is accepted).
+
+Example:
+  ${0##*/} 4.15.0
+EOF
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+# update_file <file> <locator-regex> <sed-substitution> <description>
+update_file() {
+  local file="$1" locator="$2" substitution="$3" description="$4"
+
+  [[ -f "$file" ]] || die "file not found: ${file}"
+  grep -Eq "$locator" "$file" \
+    || die "could not find ${description} in ${file} (pattern: ${locator})"
+
+  TMP_FILE="$(mktemp)"
+  sed -E "$substitution" "$file" >"$TMP_FILE"
+  cat "$TMP_FILE" >"$file"
+  rm -f "$TMP_FILE"
+  TMP_FILE=""
+
+  echo "  ✓ ${description}"
+}
+
+main() {
+  case "${1:-}" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+  esac
+
+  [[ $# -eq 1 ]] || { usage; die "exactly one argument (the new version) is required"; }
+
+  # Accept an optional leading "v", then validate strict semver X.Y.Z.
+  local version="${1#v}"
+  [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || die "invalid version '${1}'; expected X.Y.Z (e.g. 4.15.0)"
+
+  echo "Setting version to ${version}"
+
+  # xcconfig: MARKETING_VERSION=X.Y.Z
+  update_file "$XCCONFIG" \
+    "^MARKETING_VERSION[[:space:]]*=" \
+    "s/^(MARKETING_VERSION[[:space:]]*=[[:space:]]*).*/\1${version}/" \
+    "xcconfig MARKETING_VERSION"
+
+  # MUXSDKPlayerBinding.m: static NSString *const MUXSDKPluginVersion = @"X.Y.Z";
+  update_file "$BINDING" \
+    "MUXSDKPluginVersion[[:space:]]*=[[:space:]]*@\"" \
+    "s/(MUXSDKPluginVersion[[:space:]]*=[[:space:]]*@\")[^\"]*\"/\1${version}\"/" \
+    "MUXSDKPluginVersion constant"
+
+  echo
+  echo "Done. Review the changes with 'git diff' before committing."
+}
+
+main "$@"

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -1,24 +1,14 @@
 #!/usr/bin/env bash
 #
-# set-version.sh — Set a new release version across the codebase.
-#
-# Usage:
-#   scripts/set-version.sh X.Y.Z
-#
-# Mirrors scripts/set-version.sh in the other Mux iOS SDK repos so the release
-# step is the same command everywhere. Here it updates the two files that
-# hardcode the SDK version:
-#   - scripts/MUXSDKStatsFramework.xcconfig        -> MARKETING_VERSION
-#   - Sources/MUXSDKStats/MUXSDKPlayerBinding.m    -> MUXSDKPluginVersion
-#
-# It deliberately does NOT touch the MuxCore dependency version (Package.swift /
-# MUXCORE_VERSION) — that is a separate dependency on its own cadence.
+# set-version.sh X.Y.Z — set the release version in the files that hardcode it:
+#   scripts/MUXSDKStatsFramework.xcconfig     -> MARKETING_VERSION
+#   Sources/MUXSDKStats/MUXSDKPlayerBinding.m -> MUXSDKPluginVersion
+# Does NOT touch the MuxCore version (Package.swift / MUXCORE_VERSION) — separate cadence.
+# Mirrors set-version.sh in the other Mux iOS SDK repos.
 set -euo pipefail
 IFS=$'\n\t'
 
-# --- Locate the repository root relative to this script -----------------------
-# Resolve regardless of the caller's current working directory. REPO_ROOT can be
-# overridden (used by the tests).
+# Repo root, resolved regardless of cwd. REPO_ROOT can be overridden (tests).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 readonly SCRIPT_DIR REPO_ROOT

--- a/scripts/tests/fake-bin/gh
+++ b/scripts/tests/fake-bin/gh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Minimal `gh` mock for testing scripts/publish-release.sh offline.
+# State lives in $MOCK_GH_STATE (KEY=VALUE lines: EXISTS, DRAFT, ASSETS).
+# Every invocation is appended to $MOCK_GH_LOG.
+set -euo pipefail
+
+state="${MOCK_GH_STATE:?MOCK_GH_STATE not set}"
+echo "gh $*" >> "${MOCK_GH_LOG:-/dev/null}"
+
+get() { grep -E "^$1=" "$state" 2>/dev/null | head -1 | cut -d= -f2- || true; }
+set_kv() {
+    local key="$1" value="$2" tmp
+    tmp="$(mktemp)"
+    grep -vE "^$key=" "$state" 2>/dev/null > "$tmp" || true
+    echo "$key=$value" >> "$tmp"
+    mv "$tmp" "$state"
+}
+
+sub="${1:-}"
+action="${2:-}"
+
+case "$sub $action" in
+    "release view")
+        [[ "$(get EXISTS)" == "true" ]] || { echo "release not found" >&2; exit 1; }
+        draft="$(get DRAFT)"; assets="$(get ASSETS)"
+        assets_arr="$(printf '%s' "$assets" | tr ',' '\n' | sed '/^$/d' | jq -R '{name: .}' | jq -s '.')"
+        jq -n \
+            --argjson isDraft "${draft:-false}" \
+            --argjson assets "$assets_arr" \
+            --arg url "https://github.com/muxinc/mux-stats-sdk-avplayer/releases/tag/$(get TAG)" \
+            '{isDraft: $isDraft, assets: $assets, url: $url}'
+        ;;
+    "release create")
+        set_kv EXISTS true
+        set_kv DRAFT true
+        echo "created"
+        ;;
+    "release upload")
+        shift 2 # drop "release" "upload"
+        tag=""; files=()
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --repo) shift 2; continue ;;
+                --clobber) shift; continue ;;
+                --*) shift; continue ;;
+                *) if [[ -z "$tag" ]]; then tag="$1"; else files+=("$1"); fi; shift ;;
+            esac
+        done
+        assets="$(get ASSETS)"
+        for f in "${files[@]}"; do
+            base="$(basename "$f")"
+            assets="${assets:+$assets,}$base"
+        done
+        set_kv ASSETS "$assets"
+        echo "uploaded ${files[*]:-}"
+        ;;
+    *)
+        echo "fake gh: unhandled command: $*" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/tests/test-publish-release.sh
+++ b/scripts/tests/test-publish-release.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Offline tests for scripts/publish-release.sh.
+# Uses a fake `gh` (scripts/tests/fake-bin/gh) and synthetic fixtures, so it
+# makes no network calls and needs no credentials. Run: bash scripts/tests/test-publish-release.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+readonly REPO_ROOT WORK
+readonly SCRIPT="$REPO_ROOT/scripts/publish-release.sh"
+readonly FAKE_BIN="$REPO_ROOT/scripts/tests/fake-bin"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+# Build a fixture artifacts dir whose podspec checksum matches its zip.
+make_fixtures() {
+    local dir="$1" version="$2"
+    mkdir -p "$dir"
+    printf 'dummy-xcframework-zip-bytes' > "$dir/Cocoapods-Mux-Stats-AVPlayer.zip"
+    local sum
+    sum="$(shasum -a 256 "$dir/Cocoapods-Mux-Stats-AVPlayer.zip" | awk '{ print $1 }')"
+    cat > "$dir/Mux-Stats-AVPlayer.podspec" <<EOF
+Pod::Spec.new do |s|
+  s.name    = 'Mux-Stats-AVPlayer'
+  s.version = '${version}'
+  s.source  = { :http => 'https://github.com/muxinc/mux-stats-sdk-avplayer/releases/download/v${version}/Cocoapods-Mux-Stats-AVPlayer.zip',
+                :sha256 => '${sum}' }
+end
+EOF
+}
+
+# run_case <name> <expected: ok|err> <grep-needle-or-""> -- <env assignments...>
+run_case() {
+    local name="$1" expect="$2" needle="$3"; shift 4 # drop name expect needle "--"
+    local out rc
+    out="$(env "$@" \
+        PATH="$FAKE_BIN:$PATH" \
+        bash "$SCRIPT" 2>&1)"
+    rc=$?
+
+    local ok=1
+    if [[ "$expect" == "ok" && $rc -ne 0 ]]; then ok=0; fi
+    if [[ "$expect" == "err" && $rc -eq 0 ]]; then ok=0; fi
+    if [[ -n "$needle" ]] && ! grep -qiF "$needle" <<<"$out"; then ok=0; fi
+
+    if [[ $ok -eq 1 ]]; then
+        pass=$((pass + 1)); printf '  PASS  %s\n' "$name"
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s (rc=%d, expected=%s, needle=%q)\n' "$name" "$rc" "$expect" "$needle"
+        awk '{ print "        | " $0 }' <<<"$out"
+    fi
+}
+
+# Fresh mock state file; optionally pre-seed an existing release.
+new_state() {
+    local file="$WORK/state.$RANDOM"
+    : > "$file"
+    [[ -n "${1:-}" ]] && printf '%s\n' "$@" >> "$file"
+    echo "$file"
+}
+
+echo "Testing scripts/publish-release.sh (offline)"
+
+# 1. Happy path: no release yet -> create draft + upload.
+fx="$WORK/fx1"; make_fixtures "$fx" "9.9.9"; st="$(new_state "TAG=v9.9.9")"
+run_case "happy path: creates draft and uploads" ok "Attached assets" -- \
+    VERSION=v9.9.9 ARTIFACTS_DIR="$fx" GITHUB_TOKEN=tok \
+    MOCK_GH_STATE="$st" MOCK_GH_LOG="$st.log"
+if grep -q "release create" "$st.log" && grep -q "release upload" "$st.log"; then
+    pass=$((pass+1)); echo "  PASS  happy path: called release create + upload"
+else
+    fail=$((fail+1)); echo "  FAIL  happy path: expected create + upload in gh log"
+fi
+
+# 2. Draft already exists -> reuse (no create), still uploads.
+fx="$WORK/fx2"; make_fixtures "$fx" "9.9.9"; st="$(new_state "EXISTS=true" "DRAFT=true" "TAG=v9.9.9")"
+run_case "existing draft: reuses and uploads" ok "Using draft release" -- \
+    VERSION=v9.9.9 ARTIFACTS_DIR="$fx" GITHUB_TOKEN=tok \
+    MOCK_GH_STATE="$st" MOCK_GH_LOG="$st.log"
+if ! grep -q "release create" "$st.log" && grep -q "release upload" "$st.log"; then
+    pass=$((pass+1)); echo "  PASS  existing draft: did NOT create, did upload"
+else
+    fail=$((fail+1)); echo "  FAIL  existing draft: should reuse (no create) but upload"
+fi
+
+# 3. Release already PUBLISHED -> refuse.
+fx="$WORK/fx3"; make_fixtures "$fx" "9.9.9"; st="$(new_state "EXISTS=true" "DRAFT=false" "TAG=v9.9.9")"
+run_case "published release: refuses to modify" err "already published" -- \
+    VERSION=v9.9.9 ARTIFACTS_DIR="$fx" GITHUB_TOKEN=tok \
+    MOCK_GH_STATE="$st" MOCK_GH_LOG="$st.log"
+
+# 4. Tampered zip -> checksum mismatch.
+fx="$WORK/fx4"; make_fixtures "$fx" "9.9.9"; printf 'tamper' >> "$fx/Cocoapods-Mux-Stats-AVPlayer.zip"
+st="$(new_state)"
+run_case "tampered zip: checksum mismatch fails" err "checksum" -- \
+    VERSION=v9.9.9 ARTIFACTS_DIR="$fx" GITHUB_TOKEN=tok \
+    MOCK_GH_STATE="$st" MOCK_GH_LOG="$st.log"
+
+# 5. Version mismatch -> fails before touching GitHub.
+fx="$WORK/fx5"; make_fixtures "$fx" "9.9.9"; st="$(new_state)"
+run_case "version mismatch: rejects podspec" err "version does not match" -- \
+    VERSION=v1.2.3 ARTIFACTS_DIR="$fx" GITHUB_TOKEN=tok \
+    MOCK_GH_STATE="$st" MOCK_GH_LOG="$st.log"
+
+# 6. Missing artifact -> fails.
+fx="$WORK/fx6"; mkdir -p "$fx"; st="$(new_state)"
+run_case "missing artifact: fails" err "Missing artifact" -- \
+    VERSION=v9.9.9 ARTIFACTS_DIR="$fx" GITHUB_TOKEN=tok \
+    MOCK_GH_STATE="$st" MOCK_GH_LOG="$st.log"
+
+# 7. Missing token -> fails.
+fx="$WORK/fx7"; make_fixtures "$fx" "9.9.9"; st="$(new_state)"
+run_case "missing token: fails" err "No GitHub token" -- \
+    VERSION=v9.9.9 ARTIFACTS_DIR="$fx" GITHUB_TOKEN= GH_TOKEN= \
+    MOCK_GH_STATE="$st" MOCK_GH_LOG="$st.log"
+
+# 8. Bad version format -> fails.
+fx="$WORK/fx8"; make_fixtures "$fx" "9.9.9"; st="$(new_state)"
+run_case "bad version format: fails" err "must look like" -- \
+    VERSION=not-a-version ARTIFACTS_DIR="$fx" GITHUB_TOKEN=tok \
+    MOCK_GH_STATE="$st" MOCK_GH_LOG="$st.log"
+
+echo
+echo "Results: $pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/scripts/tests/test-set-version.sh
+++ b/scripts/tests/test-set-version.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Offline tests for scripts/set-version.sh.
+# Runs against fixture copies in a temp REPO_ROOT, never the real files.
+set -uo pipefail
+
+REPO_ROOT_REAL="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+readonly REPO_ROOT_REAL WORK
+readonly SCRIPT="$REPO_ROOT_REAL/scripts/set-version.sh"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+# Build a fixture repo at $1 with version $2 in both files (+ an unrelated
+# MUXSDKPluginVersion *use* that must NOT be rewritten).
+make_repo() {
+    local root="$1" version="$2"
+    mkdir -p "$root/scripts" "$root/Sources/MUXSDKStats"
+    printf 'MARKETING_VERSION=%s\n' "$version" > "$root/scripts/MUXSDKStatsFramework.xcconfig"
+    cat > "$root/Sources/MUXSDKStats/MUXSDKPlayerBinding.m" <<EOF
+static NSString *const MUXSDKPluginVersion = @"${version}";
+
+- (void)example {
+    [playerData setPlayerMuxPluginVersion:MUXSDKPluginVersion];
+}
+EOF
+}
+
+check() {
+    local name="$1" cond="$2"
+    if eval "$cond"; then
+        pass=$((pass + 1)); printf '  PASS  %s\n' "$name"
+    else
+        fail=$((fail + 1)); printf '  FAIL  %s\n' "$name"
+    fi
+}
+
+echo "Testing scripts/set-version.sh (offline)"
+
+# 1. Happy path: both files bumped, unrelated usage line untouched.
+repo="$WORK/r1"; make_repo "$repo" "0.0.0"
+REPO_ROOT="$repo" bash "$SCRIPT" 4.15.0 >/dev/null
+check "happy: MARKETING_VERSION bumped" \
+    "grep -q '^MARKETING_VERSION=4.15.0$' '$repo/scripts/MUXSDKStatsFramework.xcconfig'"
+check "happy: MUXSDKPluginVersion bumped" \
+    "grep -q 'MUXSDKPluginVersion = @\"4.15.0\";' '$repo/Sources/MUXSDKStats/MUXSDKPlayerBinding.m'"
+check "happy: usage line left intact" \
+    "grep -q 'setPlayerMuxPluginVersion:MUXSDKPluginVersion' '$repo/Sources/MUXSDKStats/MUXSDKPlayerBinding.m'"
+check "happy: no stray 0.0.0 left" \
+    "! grep -rq '0.0.0' '$repo'"
+
+# 2. Leading 'v' accepted.
+repo="$WORK/r2"; make_repo "$repo" "0.0.0"
+REPO_ROOT="$repo" bash "$SCRIPT" v4.16.0 >/dev/null
+check "leading v: strips to 4.16.0" \
+    "grep -q '^MARKETING_VERSION=4.16.0$' '$repo/scripts/MUXSDKStatsFramework.xcconfig'"
+
+# 3. Idempotent re-run.
+REPO_ROOT="$repo" bash "$SCRIPT" 4.16.0 >/dev/null
+check "idempotent: re-run keeps 4.16.0" \
+    "grep -q 'MUXSDKPluginVersion = @\"4.16.0\";' '$repo/Sources/MUXSDKStats/MUXSDKPlayerBinding.m'"
+
+# 4. Invalid version rejected (and nothing changed).
+repo="$WORK/r4"; make_repo "$repo" "0.0.0"
+REPO_ROOT="$repo" bash "$SCRIPT" 4.15 >/dev/null 2>&1
+check "invalid version: exits non-zero" "[[ $? -ne 0 ]]"
+check "invalid version: leaves files unchanged" \
+    "grep -q '^MARKETING_VERSION=0.0.0$' '$repo/scripts/MUXSDKStatsFramework.xcconfig'"
+
+# 5. Missing argument rejected.
+REPO_ROOT="$WORK/r4" bash "$SCRIPT" >/dev/null 2>&1
+check "missing arg: exits non-zero" "[[ $? -ne 0 ]]"
+
+# 6. --help exits 0.
+REPO_ROOT="$WORK/r4" bash "$SCRIPT" --help >/dev/null 2>&1
+check "--help: exits 0" "[[ $? -eq 0 ]]"
+
+# 7. Locator missing -> fails loudly.
+repo="$WORK/r7"; make_repo "$repo" "0.0.0"
+: > "$repo/scripts/MUXSDKStatsFramework.xcconfig" # wipe MARKETING_VERSION line
+REPO_ROOT="$repo" bash "$SCRIPT" 4.15.0 >/dev/null 2>&1
+check "missing locator: exits non-zero" "[[ $? -ne 0 ]]"
+
+echo
+echo "Results: $pass passed, $fail failed"
+[[ $fail -eq 0 ]]

--- a/scripts/tests/test-set-version.sh
+++ b/scripts/tests/test-set-version.sh
@@ -63,24 +63,24 @@ check "idempotent: re-run keeps 4.16.0" \
 
 # 4. Invalid version rejected (and nothing changed).
 repo="$WORK/r4"; make_repo "$repo" "0.0.0"
-REPO_ROOT="$repo" bash "$SCRIPT" 4.15 >/dev/null 2>&1
-check "invalid version: exits non-zero" "[[ $? -ne 0 ]]"
+REPO_ROOT="$repo" bash "$SCRIPT" 4.15 >/dev/null 2>&1; rc=$?
+check "invalid version: exits non-zero" "[[ $rc -ne 0 ]]"
 check "invalid version: leaves files unchanged" \
     "grep -q '^MARKETING_VERSION=0.0.0$' '$repo/scripts/MUXSDKStatsFramework.xcconfig'"
 
 # 5. Missing argument rejected.
-REPO_ROOT="$WORK/r4" bash "$SCRIPT" >/dev/null 2>&1
-check "missing arg: exits non-zero" "[[ $? -ne 0 ]]"
+REPO_ROOT="$WORK/r4" bash "$SCRIPT" >/dev/null 2>&1; rc=$?
+check "missing arg: exits non-zero" "[[ $rc -ne 0 ]]"
 
 # 6. --help exits 0.
-REPO_ROOT="$WORK/r4" bash "$SCRIPT" --help >/dev/null 2>&1
-check "--help: exits 0" "[[ $? -eq 0 ]]"
+REPO_ROOT="$WORK/r4" bash "$SCRIPT" --help >/dev/null 2>&1; rc=$?
+check "--help: exits 0" "[[ $rc -eq 0 ]]"
 
 # 7. Locator missing -> fails loudly.
 repo="$WORK/r7"; make_repo "$repo" "0.0.0"
 : > "$repo/scripts/MUXSDKStatsFramework.xcconfig" # wipe MARKETING_VERSION line
-REPO_ROOT="$repo" bash "$SCRIPT" 4.15.0 >/dev/null 2>&1
-check "missing locator: exits non-zero" "[[ $? -ne 0 ]]"
+REPO_ROOT="$repo" bash "$SCRIPT" 4.15.0 >/dev/null 2>&1; rc=$?
+check "missing locator: exits non-zero" "[[ $rc -ne 0 ]]"
 
 echo
 echo "Results: $pass passed, $fail failed"


### PR DESCRIPTION
## Summary

Replaces the manual "download artifacts from Buildkite, upload to the GitHub release by hand" step with a tag-driven flow.

## What changed

- **`.github/workflows/tagged-release-pr.yml`** — on a merged `releases/vX.Y.Z` PR, create the `vX.Y.Z` tag **and** a draft release (generated notes). Was: draft release only.
- **`.buildkite/pipeline.yml`** — new tag-only **`Publish Release Artifacts`** step (build pod → upload to the draft). Tag builds are **lean**: the standard CI steps are skipped on a tag (that commit was already validated on the release branch + master), so a tag build runs *only* Publish.
- **`scripts/publish-release.sh`** — verify (version + source URL + SHA-256) and upload the artifacts to the draft; refuses to touch an already-published release.
- **`scripts/set-version.sh`** — one-command version bump (`MARKETING_VERSION` + `MUXSDKPluginVersion`); mirrors the sibling SDK repos.
- **`scripts/tests/` + `.github/workflows/test-scripts.yml`** — offline test suites (mocked `gh` + fixtures) plus a CI job that runs them on PRs touching `scripts/`.

## How it works

`releases/vX.Y.Z` PR merges → the workflow creates the tag + draft release → the tag triggers the Buildkite publish step → artifacts are built, verified, and uploaded to the draft → a maintainer reviews the notes and publishes. SwiftPM resolves from the tag. GitHub owns the release object; Buildkite owns the binaries.

## Testing

- **Offline suites** (21 cases) — now run in CI via `test-scripts.yml`; shellcheck clean.
- **Full dry-run on real infra** (`v99.99.99`): tag → Buildkite → signed pod build → draft release with both artifacts (15.7 MB zip + podspec), then cleaned up. Lean tag build confirmed (only Publish ran).

## Notes

- The pod is built twice per release: `pod lib lint` validation on the `releases/*` branch (pre-merge) and the signed artifact on the tag. Intentional.
- `pod trunk push` stays manual (out of scope; CocoaPods is being retired anyway).
- The agent-facing release runbook (`RELEASING.md`) follows in a separate PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release tagging, GitHub release state, and artifact upload paths; mistakes could affect published binaries, though guards refuse modifying published releases and verify checksums.
> 
> **Overview**
> Replaces manual Buildkite artifact download and GitHub upload with a **tag-driven release pipeline**: merge a `releases/vX.Y.Z` PR → GitHub creates the `vX.Y.Z` tag and a draft release → Buildkite runs only on that tag to build and attach CocoaPods assets.
> 
> **GitHub Actions** (`tagged-release-pr.yml`) now pushes the version tag on the merge commit (with idempotency checks), creates or reuses a draft release via `gh`, and comments on the PR. It drops `actions/create-release@v1` in favor of explicit `gh` API calls.
> 
> **Buildkite** skips normal CI when `build.tag` matches `vX.Y.Z` and adds a **Publish Release Artifacts** step that runs `build-pod.sh` then `publish-release.sh`. Non-tag builds get `if: build.tag == null` on unit/integration/CI steps; the SPM example build condition is tightened similarly.
> 
> **New scripts:** `publish-release.sh` validates podspec version, download URL, and SHA-256 against the zip, uploads to the draft release, and refuses published releases. `set-version.sh` bumps `MARKETING_VERSION` and `MUXSDKPluginVersion` in one command.
> 
> **Testing:** offline suites with a fake `gh`, plus `test-scripts.yml` running `scripts/tests/test-*.sh` on PRs that touch `scripts/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4af749e81979ff822eb6aaad9cafa02aadbf22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->