### PR TITLE
NAT-473: Send error event for AVPlayerItem.failedToPlayToEndTimeNotification

### DIFF
--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -396,7 +396,7 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
         return;
     }
 
-    // Skip if an error was already dispatched for this session.
+    // MUXSDKPlayerStateError indicates an error was already dispatched for this failure.
     if (!_automaticErrorTracking || _state == MUXSDKPlayerStateError || ![self isNotificationAboutCurrentPlayerItem:notification] || ![self hasPlayer]) {
         return;
     }

--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -388,6 +388,14 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
 # pragma mark AVPlayerItemFailedToPlayToEndTime
 
 - (void)handleFailedToPlayToEndTimeNotification:(NSNotification *)notification {
+    if (!NSThread.isMainThread) {
+        __weak typeof(self) weakSelf = self;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [weakSelf handleFailedToPlayToEndTimeNotification:notification];
+        });
+        return;
+    }
+
     // Skip if an error was already dispatched for this session.
     if (!_automaticErrorTracking || _state == MUXSDKPlayerStateError || ![self isNotificationAboutCurrentPlayerItem:notification] || ![self hasPlayer]) {
         return;

--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -211,6 +211,7 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleAVPlayerAccess:) name:AVPlayerItemNewAccessLogEntryNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleRenditionChange:) name:RenditionChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleAVPlayerError:) name:AVPlayerItemNewErrorLogEntryNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleFailedToPlayToEndTimeNotification:) name:AVPlayerItemFailedToPlayToEndTimeNotification object:nil];
     
     _lastTransferEventCount = 0;
     _lastTransferDuration= 0;
@@ -384,6 +385,30 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
     }
 }
 
+# pragma mark AVPlayerItemFailedToPlayToEndTime
+
+- (void)handleFailedToPlayToEndTimeNotification:(NSNotification *)notification {
+    // Skip if an error was already dispatched for this session.
+    if (!_automaticErrorTracking || _state == MUXSDKPlayerStateError || ![self isNotificationAboutCurrentPlayerItem:notification] || ![self hasPlayer]) {
+        return;
+    }
+    NSError *error = notification.userInfo[AVPlayerItemFailedToPlayToEndTimeErrorKey];
+    if (![error isKindOfClass:[NSError class]]) {
+        return;
+    }
+    [self checkVideoData];
+    MUXSDKPlayerData *playerData = [self getPlayerData];
+    NSInteger errorCode = error.code;
+    if (errorCode != 0 && errorCode != NSNotFound) {
+        playerData.playerErrorCode = @(errorCode).stringValue;
+    }
+    playerData.playerErrorMessage = error.localizedDescription;
+    MUXSDKErrorEvent *event = [MUXSDKErrorEvent new];
+    event.playerData = playerData;
+    event.severity = MUXSDKErrorSeverityFatal;
+    [MUXSDKCore dispatchEvent:event forPlayer:_name];
+}
+
 - (void)timeUpdateTimer:(NSTimer *)timer {
     if (![self isTryingToPlay] && ![self isBuffering] && !_isAdPlaying) {
         [self dispatchTimeUpdateFromTimer];
@@ -396,6 +421,7 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
     [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemNewAccessLogEntryNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:RenditionChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemNewErrorLogEntryNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:AVPlayerItemFailedToPlayToEndTimeNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:@"com.mux.connection-type-detected" object:nil];
 }
 

--- a/Tests/MUXSDKStatsTests/MUXSDKPlayerBindingTests.m
+++ b/Tests/MUXSDKStatsTests/MUXSDKPlayerBindingTests.m
@@ -93,6 +93,33 @@
     return binding;
 }
 
+- (MUXSDKAVPlayerViewControllerBinding *) setupViewControllerPlayerBindingForPlayer:(AVPlayer *)player
+                                                                               name:(NSString *)name {
+    AVPlayerViewController *controller = [[AVPlayerViewController alloc] init];
+    controller.player = player;
+
+    // Set up customer metadata
+    MUXSDKCustomerPlayerData *customerPlayerData = [[MUXSDKCustomerPlayerData alloc] initWithEnvironmentKey:@"A KEY"];
+    customerPlayerData.playerSoftwareName = @"TestSoftware";
+    customerPlayerData.playerSoftwareVersion = @"0.1.0";
+    MUXSDKCustomerVideoData *customerVideoData = [[MUXSDKCustomerVideoData alloc] init];
+    customerVideoData.videoTitle = @"01234";
+
+    MUXSDKCustomerData *customerData = [MUXSDKCustomerData new];
+    customerData.customerPlayerData = customerPlayerData;
+    customerData.customerVideoData = customerVideoData;
+
+    // Create Player Binding
+    __kindof MUXSDKPlayerBinding *binding = [MUXSDKStats monitorAVPlayerViewController:controller
+                                                                        withPlayerName:name
+                                                                          customerData:customerData
+                                                                automaticErrorTracking:YES
+                                                                beaconCollectionDomain:nil];
+    XCTAssert([binding isKindOfClass:MUXSDKAVPlayerViewControllerBinding.class]);
+    XCTAssertEqual(binding.state, MUXSDKPlayerStateReady);
+    return binding;
+}
+
 - (void)testPlayerBindingStateUnknownAtInitialization {
     MUXSDKPlayerBinding *binding = [[MUXSDKPlayerBinding alloc] initWithName:MUXSDKUniquePlayerName()
                                                                  andSoftware:@"TestSoftware"];
@@ -259,6 +286,71 @@
                    playbackEvent.playerData.playerSoftwareVersion,
                    @"0.1.0"
                    );
+}
+
+- (void)testFailedToPlayToEndTimeDispatchesErrorEventWithoutErrorState {
+    NSString *name = MUXSDKUniquePlayerName();
+    NSURL *url = [[NSURL alloc] initWithString:@"https://foo.mp4"];
+    AVPlayer *player = [AVPlayer playerWithURL:url];
+    MUXSDKAVPlayerViewControllerBinding *binding = [self setupViewControllerPlayerBindingForPlayer:player
+                                                                                              name:name];
+
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                         code:NSURLErrorNetworkConnectionLost
+                                     userInfo:@{NSLocalizedDescriptionKey: @"The network connection was lost."}];
+    [[NSNotificationCenter defaultCenter] postNotificationName:AVPlayerItemFailedToPlayToEndTimeNotification
+                                                        object:player.currentItem
+                                                      userInfo:@{AVPlayerItemFailedToPlayToEndTimeErrorKey: error}];
+
+    XCTAssertNotEqual(binding.state, MUXSDKPlayerStateError);
+    XCTAssertEqual(5, [MUXSDKCore eventsCountForPlayer:name]);
+    id<MUXSDKEventTyping> event = [MUXSDKCore eventAtIndex:4 forPlayer:name];
+    XCTAssertEqual([event getType], MUXSDKPlaybackEventErrorEventType);
+
+    MUXSDKErrorEvent *errorEvent = (MUXSDKErrorEvent *)event;
+    XCTAssertEqualObjects(errorEvent.playerData.playerErrorCode, @"-1005");
+    XCTAssertEqualObjects(errorEvent.playerData.playerErrorMessage, @"The network connection was lost.");
+    XCTAssertEqual(errorEvent.severity, MUXSDKErrorSeverityFatal);
+}
+
+- (void)testFailedToPlayToEndTimeIgnoresOtherPlayerItems {
+    NSString *name = MUXSDKUniquePlayerName();
+    NSURL *url = [[NSURL alloc] initWithString:@"https://foo.mp4"];
+    AVPlayer *player = [AVPlayer playerWithURL:url];
+    MUXSDKAVPlayerViewControllerBinding *binding = [self setupViewControllerPlayerBindingForPlayer:player
+                                                                                              name:name];
+    NSUInteger eventsCountBefore = [MUXSDKCore eventsCountForPlayer:name];
+
+    AVPlayerItem *otherItem = [AVPlayerItem playerItemWithURL:url];
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                         code:NSURLErrorNetworkConnectionLost
+                                     userInfo:@{NSLocalizedDescriptionKey: @"The network connection was lost."}];
+    [[NSNotificationCenter defaultCenter] postNotificationName:AVPlayerItemFailedToPlayToEndTimeNotification
+                                                        object:otherItem
+                                                      userInfo:@{AVPlayerItemFailedToPlayToEndTimeErrorKey: error}];
+
+    XCTAssertNotEqual(binding.state, MUXSDKPlayerStateError);
+    XCTAssertEqual(eventsCountBefore, [MUXSDKCore eventsCountForPlayer:name]);
+}
+
+- (void)testFailedToPlayToEndTimeAutomaticErrorTrackingDisabled {
+    NSString *name = MUXSDKUniquePlayerName();
+    NSURL *url = [[NSURL alloc] initWithString:@"https://foo.mp4"];
+    AVPlayer *player = [AVPlayer playerWithURL:url];
+    MUXSDKAVPlayerViewControllerBinding *binding = [self setupViewControllerPlayerBindingForPlayer:player
+                                                                                              name:name];
+    [binding setAutomaticErrorTracking:false];
+    NSUInteger eventsCountBefore = [MUXSDKCore eventsCountForPlayer:name];
+
+    NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                         code:NSURLErrorNetworkConnectionLost
+                                     userInfo:@{NSLocalizedDescriptionKey: @"The network connection was lost."}];
+    [[NSNotificationCenter defaultCenter] postNotificationName:AVPlayerItemFailedToPlayToEndTimeNotification
+                                                        object:player.currentItem
+                                                      userInfo:@{AVPlayerItemFailedToPlayToEndTimeErrorKey: error}];
+
+    XCTAssertNotEqual(binding.state, MUXSDKPlayerStateError);
+    XCTAssertEqual(eventsCountBefore, [MUXSDKCore eventsCountForPlayer:name]);
 }
 
 - (void)testAVPlayerBindingAutomaticErrorTrackingEnabled {


### PR DESCRIPTION
Reports an error event for `AVPlayerItem.failedToPlayToEndTimeNotification`. Notably this does not set the internal SDK state to `MUXSDKPlayerStateError`, as playback can still be reattempted manually. The existing error dispatch methods do this automatically, hence why they were avoided here.

Resolves [NAT-473].

[NAT-473]: https://mux1.atlassian.net/browse/NAT-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped analytics change in player binding with guards and unit tests; no auth or data-model changes.
> 
> **Overview**
> Adds handling for **`AVPlayerItemFailedToPlayToEndTimeNotification`** so mid-playback failures that prevent reaching the end are reported to Mux analytics.
> 
> `MUXSDKPlayerBinding` registers for the notification on attach and removes it on teardown. The handler runs on the main thread, respects **`automaticErrorTracking`**, ignores notifications for other items or when the binding is already in **`MUXSDKPlayerStateError`**, and emits a **fatal** `MUXSDKErrorEvent` with code and message from `AVPlayerItemFailedToPlayToEndTimeErrorKey`. It **does not** transition internal state to error (unlike `dispatchError`), so manual retry remains possible.
> 
> Tests cover successful dispatch, filtering by current item, and disabled automatic error tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dfa713435557ed98777ea587dd4c74d8eb9492b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->