### PR TITLE
NAT-456: Fix release tag and draft lookup

### DIFF
--- a/.github/workflows/tagged-release-pr.yml
+++ b/.github/workflows/tagged-release-pr.yml
@@ -17,54 +17,23 @@ jobs:
     if: startsWith(github.head_ref, 'releases/v') && github.event.pull_request.merged
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Derive tag from the release branch
         id: version
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: echo "tag=${HEAD_REF#releases/}" >> "$GITHUB_OUTPUT"
 
-      - name: Create and push the tag
+      - name: Create the tag and draft release
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
           SHA: ${{ github.event.pull_request.merge_commit_sha }}
           REPO: ${{ github.repository }}
-        run: |
-          existing="$(gh api "repos/${REPO}/git/ref/tags/${TAG}" --jq '.object.sha' 2>/dev/null || true)"
-          if [[ -z "${existing}" ]]; then
-            gh api "repos/${REPO}/git/refs" -f ref="refs/tags/${TAG}" -f sha="${SHA}"
-            echo "Created tag ${TAG} at ${SHA}"
-          elif [[ "${existing}" == "${SHA}" ]]; then
-            echo "Tag ${TAG} already exists at ${SHA}; continuing."
-          else
-            echo "Tag ${TAG} already exists but points to ${existing}, not ${SHA}." >&2
-            exit 1
-          fi
-
-      - name: Create the draft GitHub release
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ steps.version.outputs.tag }}
-          REPO: ${{ github.repository }}
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          state="$(gh release view "${TAG}" --repo "${REPO}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-          if [[ "${state}" == "true" ]]; then
-            echo "Draft release ${TAG} already exists; continuing."
-          elif [[ "${state}" == "false" ]]; then
-            echo "Release ${TAG} already exists and is published; refusing to proceed." >&2
-            exit 1
-          else
-            gh release create "${TAG}" \
-              --repo "${REPO}" \
-              --draft \
-              --verify-tag \
-              --title "${TAG}" \
-              --notes "${PR_BODY}"
-            echo "Created draft release ${TAG}"
-          fi
+        run: scripts/create-tagged-release.sh
 
       - name: Comment on the PR
         env:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths:
       - 'scripts/**'
+      - '.github/workflows/tagged-release-pr.yml'
 
 jobs:
   test:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -60,6 +60,9 @@ is missing, stop and ask a maintainer rather than working around it.
   installation token or fine-grained token — not a personal token), and has
   `gh` on `PATH`.
 - CocoaPods trunk access is available locally for the final `pod trunk push`.
+- The active local Xcode has simulator runtimes matching its SDK version for
+  every platform declared by the podspec (iOS, tvOS, and visionOS). Check with
+  `xcodebuild -version` and `xcrun simctl list runtimes` before validation.
 
 ## Release Runbook
 
@@ -135,10 +138,16 @@ version.
 
 8. Validate locally where possible.
    ```sh
-   xcrun swift build
-   xcrun swift test
+   for test_script in scripts/tests/test-*.sh; do bash "$test_script"; done
+   ./scripts/build-package.sh
+   ./scripts/unit-test-package.sh
    git diff --check
    ```
+   Do not use plain `swift build` or `swift test`: they target native macOS,
+   which the MuxCore XCFramework does not support. The repository scripts build
+   and test the supported Apple platforms instead. If a platform leg fails
+   because its matching simulator runtime is unavailable, install that runtime
+   before continuing.
    Do not claim Buildkite has passed before it has.
 
 9. Commit, push, and open the release PR.
@@ -152,6 +161,8 @@ version.
 10. Wait for the changelog workflow to update the PR, then review and curate the
     release notes with the maintainer. On a release branch, Buildkite also runs
     the version check, full SPM test, and pod lint — confirm these pass.
+    Compare the changes since the previous release tag; do not accept notes that
+    only say `Version Bump` when customer-facing changes are included.
 
 11. Stop until the PR is approved and merged.
 
@@ -230,12 +241,21 @@ only resolves once the release is public).
    ```
    Both greps must succeed — the version and source URL match this release.
 
-3. Publish to CocoaPods.
+3. Run a final local lint of the downloaded podspec.
+   ```sh
+   xcodebuild -version
+   xcrun simctl list runtimes
+   pod spec lint Mux-Stats-AVPlayer.podspec
+   ```
+   Confirm the active Xcode has matching iOS, tvOS, and visionOS runtimes. Do
+   not bypass a missing-platform failure with skip flags.
+
+4. Publish to CocoaPods.
    ```sh
    pod trunk push Mux-Stats-AVPlayer.podspec
    ```
 
-4. Confirm CocoaPods sees the new version.
+5. Confirm CocoaPods sees the new version.
    ```sh
    pod trunk info Mux-Stats-AVPlayer
    ```

--- a/scripts/create-tagged-release.sh
+++ b/scripts/create-tagged-release.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create the tag and draft GitHub release for a merged releases/vX.Y.Z PR.
+# Remote lookups use list endpoints: a missing tag or release is an empty,
+# successful response, while authentication/network/API failures stay fatal.
+
+function die {
+    echo "$@" >&2
+    exit 1
+}
+
+function require_command {
+    command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+require_command gh
+require_command jq
+
+readonly TAG="${TAG:-}"
+readonly SHA="${SHA:-}"
+readonly REPO="${REPO:-${GITHUB_REPOSITORY:-}}"
+readonly PR_BODY="${PR_BODY:-}"
+
+[[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+    || die "TAG must look like vX.Y.Z (got '$TAG')."
+[[ "$SHA" =~ ^[0-9a-f]{40}$ ]] \
+    || die "SHA must be a 40-character lowercase commit SHA (got '$SHA')."
+[[ -n "$REPO" ]] || die "REPO (or GITHUB_REPOSITORY) is required."
+[[ -n "${GH_TOKEN:-${GITHUB_TOKEN:-}}" ]] \
+    || die "No GitHub token. Set GH_TOKEN (or GITHUB_TOKEN)."
+
+if [[ -n "${GITHUB_TOKEN:-}" && -z "${GH_TOKEN:-}" ]]; then
+    export GH_TOKEN="$GITHUB_TOKEN"
+fi
+
+readonly expected_ref="refs/tags/$TAG"
+refs_json="$(gh api "repos/${REPO}/git/matching-refs/tags/${TAG}")"
+existing="$(jq --raw-output --arg ref "$expected_ref" \
+    '.[] | select(.ref == $ref) | .object.sha' <<<"$refs_json")"
+
+if [[ -z "$existing" ]]; then
+    gh api "repos/${REPO}/git/refs" \
+        -f ref="$expected_ref" \
+        -f sha="$SHA" >/dev/null
+    echo "Created tag $TAG at $SHA."
+elif [[ "$existing" == "$SHA" ]]; then
+    echo "Tag $TAG already exists at $SHA; continuing."
+else
+    die "Tag $TAG already exists but points to $existing, not $SHA."
+fi
+
+releases_json="$(gh release list \
+    --repo "$REPO" \
+    --limit 1000 \
+    --json tagName,isDraft)"
+release_state="$(jq --raw-output --arg tag "$TAG" \
+    '.[] | select(.tagName == $tag) | .isDraft' <<<"$releases_json")"
+
+case "$release_state" in
+    true)
+        echo "Draft release $TAG already exists; continuing."
+        ;;
+    false)
+        die "Release $TAG already exists and is published; refusing to proceed."
+        ;;
+    "")
+        gh release create "$TAG" \
+            --repo "$REPO" \
+            --draft \
+            --verify-tag \
+            --title "$TAG" \
+            --notes "$PR_BODY" >/dev/null
+        echo "Created draft release $TAG."
+        ;;
+    *)
+        die "Unexpected release state for $TAG: $release_state"
+        ;;
+esac

--- a/scripts/tests/fake-bin/gh
+++ b/scripts/tests/fake-bin/gh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Minimal `gh` mock for testing scripts/publish-release.sh offline.
-# State lives in $MOCK_GH_STATE (KEY=VALUE lines: EXISTS, DRAFT, ASSETS).
+# Minimal `gh` mock for testing release scripts offline.
+# State lives in $MOCK_GH_STATE (KEY=VALUE lines).
 # Every invocation is appended to $MOCK_GH_LOG.
 set -euo pipefail
 
@@ -19,7 +19,69 @@ set_kv() {
 sub="${1:-}"
 action="${2:-}"
 
+if [[ "$sub" == "api" ]]; then
+    endpoint="$action"
+    if [[ "$(get API_FAIL)" == "true" ]]; then
+        echo "simulated GitHub API failure" >&2
+        exit 1
+    fi
+
+    case "$endpoint" in
+        */git/matching-refs/tags/*)
+            exact_sha="$(get TAG_SHA)"
+            partial_sha="$(get PARTIAL_TAG_SHA)"
+            jq -n \
+                --arg tag "$(get TAG)" \
+                --arg exact "$exact_sha" \
+                --arg partial "$partial_sha" \
+                '[
+                    if $exact == "" then empty else
+                        {ref: ("refs/tags/" + $tag), object: {sha: $exact}}
+                    end,
+                    if $partial == "" then empty else
+                        {ref: ("refs/tags/" + $tag + "-partial"), object: {sha: $partial}}
+                    end
+                ]'
+            exit 0
+            ;;
+        */git/refs)
+            ref=""; sha=""
+            shift 2
+            while [[ $# -gt 0 ]]; do
+                case "$1" in
+                    ref=*) ref="${1#ref=}" ;;
+                    sha=*) sha="${1#sha=}" ;;
+                esac
+                shift
+            done
+            set_kv TAG "${ref#refs/tags/}"
+            set_kv TAG_SHA "$sha"
+            jq -n --arg ref "$ref" --arg sha "$sha" \
+                '{ref: $ref, object: {sha: $sha}}'
+            exit 0
+            ;;
+        *)
+            echo "fake gh: unhandled api endpoint: $endpoint" >&2
+            exit 2
+            ;;
+    esac
+fi
+
 case "$sub $action" in
+    "release list")
+        if [[ "$(get RELEASE_LIST_FAIL)" == "true" ]]; then
+            echo "simulated release list failure" >&2
+            exit 1
+        fi
+        if [[ "$(get EXISTS)" == "true" ]]; then
+            jq -n \
+                --arg tagName "$(get TAG)" \
+                --argjson isDraft "$(get DRAFT)" \
+                '[{tagName: $tagName, isDraft: $isDraft}]'
+        else
+            echo '[]'
+        fi
+        ;;
     "release view")
         [[ "$(get EXISTS)" == "true" ]] || { echo "release not found" >&2; exit 1; }
         draft="$(get DRAFT)"; assets="$(get ASSETS)"

--- a/scripts/tests/test-create-tagged-release.sh
+++ b/scripts/tests/test-create-tagged-release.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Offline regression tests for scripts/create-tagged-release.sh.
+# Uses the shared fake `gh`; no network or credentials are required.
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+readonly REPO_ROOT WORK
+readonly SCRIPT="$REPO_ROOT/scripts/create-tagged-release.sh"
+readonly FAKE_BIN="$REPO_ROOT/scripts/tests/fake-bin"
+readonly SHA="1111111111111111111111111111111111111111"
+readonly OTHER_SHA="2222222222222222222222222222222222222222"
+trap 'rm -rf "$WORK"' EXIT
+
+pass=0
+fail=0
+
+new_state() {
+    local file="$WORK/state.$RANDOM"
+    : > "$file"
+    [[ -n "${1:-}" ]] && printf '%s\n' "$@" >> "$file"
+    echo "$file"
+}
+
+run_case() {
+    local name="$1" expect="$2" needle="$3"; shift 4
+    local out rc ok=1
+    out="$(env "$@" \
+        PATH="$FAKE_BIN:$PATH" \
+        bash "$SCRIPT" 2>&1)"
+    rc=$?
+
+    if [[ "$expect" == "ok" && $rc -ne 0 ]]; then ok=0; fi
+    if [[ "$expect" == "err" && $rc -eq 0 ]]; then ok=0; fi
+    if [[ -n "$needle" ]] && ! grep -qiF "$needle" <<<"$out"; then ok=0; fi
+
+    if [[ $ok -eq 1 ]]; then
+        pass=$((pass + 1)); printf '  PASS  %s\n' "$name"
+    else
+        fail=$((fail + 1))
+        printf '  FAIL  %s (rc=%d, expected=%s, needle=%q)\n' \
+            "$name" "$rc" "$expect" "$needle"
+        awk '{ print "        | " $0 }' <<<"$out"
+    fi
+}
+
+set_common_env() {
+    local state="$1"
+    envs=( \
+        "TAG=v9.9.9" \
+        "SHA=$SHA" \
+        "REPO=muxinc/mux-stats-sdk-avplayer" \
+        "PR_BODY=Release notes" \
+        "GH_TOKEN=token" \
+        "MOCK_GH_STATE=$state" \
+        "MOCK_GH_LOG=$state.log" \
+    )
+}
+
+echo "Testing scripts/create-tagged-release.sh (offline)"
+
+# 1. Fresh tag and release: the path that failed during v4.15.0.
+st="$(new_state "TAG=v9.9.9")"
+set_common_env "$st"
+run_case "fresh tag: creates tag and draft" ok "Created draft release" -- "${envs[@]}"
+if grep -q "api repos/.*/git/refs" "$st.log" \
+    && grep -q "release create" "$st.log"; then
+    pass=$((pass + 1)); echo "  PASS  fresh tag: called tag + release creation"
+else
+    fail=$((fail + 1)); echo "  FAIL  fresh tag: expected tag + release creation"
+fi
+
+# 2. Idempotent rerun at the same SHA with an existing draft.
+st="$(new_state "TAG=v9.9.9" "TAG_SHA=$SHA" "EXISTS=true" "DRAFT=true")"
+set_common_env "$st"
+run_case "same tag and draft: continues" ok "already exists" -- "${envs[@]}"
+if ! grep -q "api repos/.*/git/refs -f" "$st.log" \
+    && ! grep -q "release create" "$st.log"; then
+    pass=$((pass + 1)); echo "  PASS  idempotent rerun: created nothing"
+else
+    fail=$((fail + 1)); echo "  FAIL  idempotent rerun: should create nothing"
+fi
+
+# 3. A prefix match must not be mistaken for the exact tag.
+st="$(new_state "TAG=v9.9.9" "PARTIAL_TAG_SHA=$OTHER_SHA")"
+set_common_env "$st"
+run_case "partial tag match: creates exact tag" ok "Created tag" -- "${envs[@]}"
+
+# 4. Existing exact tag at another SHA is a hard stop.
+st="$(new_state "TAG=v9.9.9" "TAG_SHA=$OTHER_SHA")"
+set_common_env "$st"
+run_case "conflicting tag: refuses" err "points to" -- "${envs[@]}"
+
+# 5. Published releases are never modified.
+st="$(new_state "TAG=v9.9.9" "TAG_SHA=$SHA" "EXISTS=true" "DRAFT=false")"
+set_common_env "$st"
+run_case "published release: refuses" err "already exists and is published" -- "${envs[@]}"
+
+# 6. Tag lookup API failures stay fatal instead of looking like a missing tag.
+st="$(new_state "TAG=v9.9.9" "API_FAIL=true")"
+set_common_env "$st"
+run_case "tag API failure: refuses" err "simulated GitHub API failure" -- "${envs[@]}"
+
+# 7. Release lookup failures stay fatal. A rerun can reuse the created tag.
+st="$(new_state "TAG=v9.9.9" "RELEASE_LIST_FAIL=true")"
+set_common_env "$st"
+run_case "release API failure: refuses" err "simulated release list failure" -- "${envs[@]}"
+
+# 8. Invalid input fails before contacting GitHub.
+st="$(new_state)"
+set_common_env "$st"
+envs[0]="TAG=not-a-tag"
+run_case "invalid tag: refuses" err "TAG must look like" -- "${envs[@]}"
+
+echo
+echo "Results: $pass passed, $fail failed"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Summary

Fix the merged-release workflow's tag and draft-release lookups, add regression coverage for the fresh-tag path, and correct the release runbook based on the v4.15.0 validation findings.

## Root cause

The workflow suppressed `gh api` failures with `|| true` and assumed an empty result meant that no tag existed. For a missing tag, `gh api` returned a 404 JSON body on stdout, which was captured as though it were the existing tag SHA.

The draft-release lookup had the same failure-shaping risk: authentication, network, and API failures could be mistaken for a missing release.

## What changed

- Move tag and draft-release creation into `scripts/create-tagged-release.sh` so the state transitions are testable.
- Use successful list endpoints for both lookups: missing state is an empty result, while API failures remain fatal.
- Preserve idempotency for an existing tag at the expected SHA and an existing draft release.
- Refuse conflicting tags and published releases.
- Add offline regression tests for fresh state, idempotent reruns, prefix matches, conflicts, published releases, and API failures.
- Run script tests when the release workflow itself changes.
- Update the runbook to use supported-platform build/test scripts, require matching simulator runtimes, reject incomplete generated notes, and lint the downloaded podspec before trunk publication.

## Validation

- All release-script suites: 31 passed, 0 failed.
- `shellcheck` passes for the changed and shared release scripts.
- Workflow YAML parses successfully.
- `git diff --check` passes.
- Real repository read-only check matched `v4.15.0` to its exact commit and correctly refused the already-published release without modifying remote state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the automated path that creates release tags and draft GitHub releases on merge; mistakes could block releases or mis-tag, though idempotency guards and tests reduce that risk.
> 
> **Overview**
> Fixes merged-release automation where **`gh api` failures were swallowed** (`|| true`) so 404 JSON on stdout could be treated as an existing tag SHA, and draft-release checks could misread API errors as “no release.”
> 
> **Tag and draft creation** now run through **`scripts/create-tagged-release.sh`**, invoked from `tagged-release-pr.yml` (with checkout added so the script is on the runner). Lookups use **list-style endpoints** (`matching-refs`, `release list`): absent tag/release is an empty success; real API failures still fail. Behavior keeps **idempotency** for the expected tag SHA and existing drafts, and **hard-stops** on conflicting tags or already-published releases.
> 
> Adds **offline regression tests** (`test-create-tagged-release.sh`) and extends the shared **`fake gh`** mock for those API paths. **`test-scripts.yml`** also runs when `tagged-release-pr.yml` changes.
> 
> **`RELEASING.md`** updates validation to use platform build/test scripts (not plain `swift build`/`test`), require matching simulator runtimes, curate release notes beyond “Version Bump,” and **`pod spec lint`** the downloaded podspec before trunk push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dcc534d4190151b35b71f03596c31038af7df1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->