### PR TITLE
NAT-474: Simplify PlayerMonitor concurrency

### DIFF
--- a/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
+++ b/Sources/MUXSDKStats/MUXSDKPlayerBinding.m
@@ -154,17 +154,16 @@ static NSString *const RemoveObserverExceptionName = @"NSRangeException";
         NSLog(@"MUXSDK-ERROR - Cannot attach to NULL AVPlayer for player name: %@", _name);
         return;
     }
+    _player = player;
+    __weak typeof(self) weakSelf = self;
     if (@available(iOS 15, tvOS 15, *)) {
         self.shouldTrackRenditionChanges = NO;
-        __weak typeof(self) weakSelf = self;
         self.swiftMonitor = [[MUXSDKPlayerMonitor alloc] initWithPlayer:player onEvent:^(MUXSDKBaseEvent *event) {
             [weakSelf dispatchSwiftMonitorEvent:event];
         }];
     } else {
         self.shouldTrackRenditionChanges = YES;
     }
-    _player = player;
-    __weak MUXSDKPlayerBinding *weakSelf = self;
     _lastTimeUpdate = CFAbsoluteTimeGetCurrent() - MUXSDKMaxSecsBetweenTimeUpdate;
     _timeObserver = [_player addPeriodicTimeObserverForInterval:[self getTimeObserverInternal]
                                                           queue:NULL

--- a/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
+++ b/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
@@ -7,21 +7,21 @@ import Combine
 @objc(MUXSDKPlayerMonitor)
 public final class PlayerMonitor: NSObject {
 
-    private var cancellable: AnyCancellable?
-
+    private let cancellationLock =  NSLock()
+    private var subscriptionHandle: AnyCancellable?
     private var isCancelledFlag: Bool = false
-    private let isCancelledLock =  NSLock()
 
-    private nonisolated var isCancelled: Bool {
-        isCancelledLock.withLock { isCancelledFlag }
+    private var isCancelled: Bool {
+        cancellationLock.withLock { isCancelledFlag }
     }
 
     /// Cancels future events and makes a best-effort attempt to cancel any in-flight onEvent callback
     @objc public nonisolated func cancel() {
-        isCancelledLock.withLock {
+        let handle = cancellationLock.withLock {
             isCancelledFlag = true
+            return exchange(&subscriptionHandle, with: nil)
         }
-        cancellable?.cancel()
+        handle?.cancel()
     }
 
     @objc public init(player: AVPlayer, onEvent: @Sendable @escaping @MainActor (MUXSDKBaseEvent) -> Void) {
@@ -50,7 +50,7 @@ public final class PlayerMonitor: NSObject {
             }
             .switchToLatest()
 
-        cancellable = allEvents
+        let handle = allEvents
             .subscribe(on: ImmediateIfOnMainQueueScheduler.shared)
             .receive(on: ImmediateIfOnMainQueueScheduler.shared)
             .sink(receiveValue: { [weak self] event in
@@ -61,5 +61,12 @@ public final class PlayerMonitor: NSObject {
                     onEvent(event)
                 }
             })
+
+        cancellationLock.withLock {
+            guard isCancelledFlag == false else {
+                return
+            }
+            subscriptionHandle = handle
+        }
     }
 }

--- a/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
+++ b/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
@@ -7,21 +7,11 @@ import Combine
 @objc(MUXSDKPlayerMonitor)
 public final class PlayerMonitor: NSObject {
 
-    private let cancellationLock =  NSLock()
-    private var subscriptionHandle: AnyCancellable?
-    private var isCancelledFlag: Bool = false
-
-    private var isCancelled: Bool {
-        cancellationLock.withLock { isCancelledFlag }
-    }
+    private let subscriptionWrapper = SubscriptionWrapper()
 
     /// Cancels future events and makes a best-effort attempt to cancel any in-flight onEvent callback
     @objc public nonisolated func cancel() {
-        let handle = cancellationLock.withLock {
-            isCancelledFlag = true
-            return exchange(&subscriptionHandle, with: nil)
-        }
-        handle?.cancel()
+        subscriptionWrapper.cancel()
     }
 
     @objc public init(player: AVPlayer, onEvent: @Sendable @escaping @MainActor (MUXSDKBaseEvent) -> Void) {
@@ -54,7 +44,7 @@ public final class PlayerMonitor: NSObject {
             .subscribe(on: ImmediateIfOnMainQueueScheduler.shared)
             .receive(on: ImmediateIfOnMainQueueScheduler.shared)
             .sink(receiveValue: { [weak self] event in
-                guard self?.isCancelled == false else {
+                guard self?.subscriptionWrapper.isCancelled == false else {
                     return
                 }
                 MainActor.assumeIsolated {
@@ -62,11 +52,40 @@ public final class PlayerMonitor: NSObject {
                 }
             })
 
-        cancellationLock.withLock {
-            guard isCancelledFlag == false else {
-                return
+        subscriptionWrapper.setOrCancelSubscriptionHandle(handle)
+    }
+}
+
+@available(iOS 15, tvOS 15, *)
+extension PlayerMonitor {
+    // Stand-in for OSAllocatedUnfairLock (unavailable on iOS 15)
+    private final class SubscriptionWrapper {
+        private let lock = NSLock()
+        // guarded by lock
+        private var subscriptionHandle: AnyCancellable?
+        // guarded by lock
+        private var isCancelledFlag: Bool = false
+
+        func setOrCancelSubscriptionHandle(_ handle: AnyCancellable) {
+            let toCancel: AnyCancellable? = lock.withLock {
+                guard isCancelledFlag == false else {
+                    return handle
+                }
+                return exchange(&subscriptionHandle, with: handle)
             }
-            subscriptionHandle = handle
+            toCancel?.cancel()
+        }
+
+        func cancel() {
+            let toCancel = lock.withLock {
+                isCancelledFlag = true
+                return exchange(&subscriptionHandle, with: nil)
+            }
+            toCancel?.cancel()
+        }
+
+        var isCancelled: Bool {
+            lock.withLock { isCancelledFlag }
         }
     }
 }

--- a/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
+++ b/Sources/MUXSDKStatsInternal/PlayerMonitor.swift
@@ -1,75 +1,65 @@
 public import AVFoundation
 import Combine
-public import MuxCore
+@preconcurrency public import MuxCore
 
-
-@available(iOS 13, tvOS 13, *)
-@objc(MUXSDKPlayerMonitor)
-public class PlayerMonitor: NSObject {
-
-    var allEvents: some Publisher<MUXSDKBaseEvent, Never> {
-        allEventsSubject
-    }
-
-    private let allEventsSubject = PassthroughSubject<MUXSDKBaseEvent, Never>()
-
-    private var cancellables = [AnyCancellable]()
-
-    @objc public func cancel() {
-        allEventsSubject.send(completion: .finished)
-        cancellables.removeAll()
-    }
-}
 
 @available(iOS 15, tvOS 15, *)
-extension PlayerMonitor {
-    convenience init(player: AVPlayer) {
-        self.init()
+@objc(MUXSDKPlayerMonitor)
+public final class PlayerMonitor: NSObject {
 
-        let currentItemPublisher = player.publisher(for: \.currentItem, options: [.initial])
-            .removeDuplicates()
+    private var cancellable: AnyCancellable?
 
-        currentItemPublisher
-            .map { $0?.renditionChangeEvents().eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher() }
-            .switchToLatest()
-            .sink(receiveValue: allEventsSubject.send)
-            .store(in: &cancellables)
+    private var isCancelledFlag: Bool = false
+    private let isCancelledLock =  NSLock()
 
-        currentItemPublisher
-            .map { $0?.textTrackChangeEvents().eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher() }
-            .switchToLatest()
-            .sink(receiveValue: allEventsSubject.send)
-            .store(in: &cancellables)
-
-        currentItemPublisher
-            .map { $0?.audioTrackChangeEvents().eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher() }
-            .switchToLatest()
-            .sink(receiveValue: allEventsSubject.send)
-            .store(in: &cancellables)
-
-#if !targetEnvironment(simulator)
-        if #available(iOS 18.0, tvOS 18.0, visionOS 2.0, *) {
-            currentItemPublisher
-                .map { $0?.requestBandwidthEvents().eraseToAnyPublisher() ?? Empty().eraseToAnyPublisher() }
-                .switchToLatest()
-                .sink(receiveValue: allEventsSubject.send)
-                .store(in: &cancellables)
-        }
-#endif
+    private nonisolated var isCancelled: Bool {
+        isCancelledLock.withLock { isCancelledFlag }
     }
 
-    @objc public convenience init(player: AVPlayer, onEvent: @Sendable @escaping @MainActor (MUXSDKBaseEvent) -> Void) {
-        self.init(player: player)
+    /// Cancels future events and makes a best-effort attempt to cancel any in-flight onEvent callback
+    @objc public nonisolated func cancel() {
+        isCancelledLock.withLock {
+            isCancelledFlag = true
+        }
+        cancellable?.cancel()
+    }
 
-        allEvents
+    @objc public init(player: AVPlayer, onEvent: @Sendable @escaping @MainActor (MUXSDKBaseEvent) -> Void) {
+        super.init()
+
+        let allEvents = player.publisher(for: \.currentItem, options: [.initial])
+            .removeDuplicates()
+            .map { (playerItem: AVPlayerItem?) -> AnyPublisher<MUXSDKBaseEvent, Never> in
+                guard let playerItem else {
+                    return Empty().eraseToAnyPublisher()
+                }
+
+                let merged = playerItem.renditionChangeEvents().map { $0 as MUXSDKBaseEvent }
+                    .merge(with: playerItem.textTrackChangeEvents().map { $0 as MUXSDKBaseEvent })
+                    .merge(with: playerItem.audioTrackChangeEvents().map { $0 as MUXSDKBaseEvent })
+
+#if !targetEnvironment(simulator)
+                if #available(iOS 18, tvOS 18, visionOS 2, *) {
+                    return merged
+                        .merge(with: playerItem.requestBandwidthEvents().map { $0 as MUXSDKBaseEvent })
+                        .eraseToAnyPublisher()
+                }
+#endif
+
+                return merged.eraseToAnyPublisher()
+            }
+            .switchToLatest()
+
+        cancellable = allEvents
+            .subscribe(on: ImmediateIfOnMainQueueScheduler.shared)
             .receive(on: ImmediateIfOnMainQueueScheduler.shared)
-            .sink(receiveValue: { event in
-                // work around Sendable requirement on assumeIsolated
-                nonisolated(unsafe) let event = event
+            .sink(receiveValue: { [weak self] event in
+                guard self?.isCancelled == false else {
+                    return
+                }
                 MainActor.assumeIsolated {
                     onEvent(event)
                 }
             })
-            .store(in: &cancellables)
     }
 }


### PR DESCRIPTION
Effectively this commits to Combine, fully scheduled on the main queue, with a cancellation flag.

- Creates a single merged stream of events using Combine's built-in functionality. This replaces the ad-hoc method that sent events from various streams to a single subject. Now there is only one Combine pipeline.
- Forces all subscription operations to happen on the main queue. It seems likely that the [NAT-474] crash comes from subscriptions being torn down on background threads while an `onEvent` callback is actively executing on the main queue
- Adds a simple best-effort cancellation check before `onEvent` calls. Pipeline cancellation (via the `AnyCancellation` object created at initialization time) now has to queue up with everything else on the main queue, but this will short-circuit any further event callbacks.

Nice things like Atomics and OSAllocatedUnfairLock aren't available in iOS/tvOS 15, so it's a bit uglier than I'd prefer.

Resolves [NAT-474].

[NAT-474]: https://mux1.atlassian.net/browse/NAT-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NAT-474]: https://mux1.atlassian.net/browse/NAT-474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core player event observation and thread-safety around teardown, which could affect crash fixes (NAT-474) but also alter timing of rendition/bandwidth callbacks; minimum Swift monitor OS moves from 13 to 15.
> 
> **Overview**
> Refactors **`PlayerMonitor`** to use one merged Combine pipeline (rendition, text/audio track, and optional bandwidth events) instead of fanning multiple streams into a shared subject, and raises the Swift monitor’s minimum OS to **iOS/tvOS 15**.
> 
> Subscription setup and delivery are pinned to the main queue via **`ImmediateIfOnMainQueueScheduler`**, with a lock-backed **`SubscriptionWrapper`** so **`cancel()`** can tear down the **`AnyCancellable`** safely from any thread and skip **`onEvent`** after cancellation. **`MuxCore`** is imported with **`@preconcurrency`**, and the unsafe sendable workaround for events is removed.
> 
> In **`MUXSDKPlayerBinding`**, **`attachAVPlayer:`** assigns **`_player`** and the weak self reference before creating the Swift monitor so teardown and the periodic time observer share the same lifetime ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3099e71eaaeb4d1d3848d883229926c57b064f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->