### PR TITLE
Avoid reordered renditionchange events

### DIFF
--- a/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
@@ -57,15 +57,13 @@ extension AVPlayerItem {
         // playback, during seeking for example. While the following will unique these
         // objects, a new object here may still refer to the same rendition:
             .removeDuplicates()
-            .flatMap { videoAssetTrack in
-                // Boost priority as this kicks off a chain of timing-sensitive operations
-                return Future(priority: .userInitiated) {
-                    async let timing = self.currentTiming()
-                    guard let videoAssetTrack else {
-                        return await (timing, MUXSDKVideoData())
-                    }
-                    return await (timing, MUXSDKVideoData.makeWithRenditionInfo(track: videoAssetTrack, on: self))
+            // Boost priority as this kicks off a chain of timing-sensitive operations
+            .map(priority: .userInitiated) { videoAssetTrack in
+                async let timing = self.currentTiming()
+                guard let videoAssetTrack else {
+                    return await (timing, MUXSDKVideoData())
                 }
+                return await (timing, MUXSDKVideoData.makeWithRenditionInfo(track: videoAssetTrack, on: self))
             }
         // Determine uniqueness (and therefore rendition changes) based on fully populated
         // video data:


### PR DESCRIPTION
`Future`s  returned from `flatMap` are not implicitly ordered, but our async `map` helper cleanly takes care of this.

Resolves [NAT-494].

[NAT-494]: https://mux1.atlassian.net/browse/NAT-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small pipeline change in analytics event ordering; behavior is more correct with no auth or data-model impact.
> 
> **Overview**
> **Fixes out-of-order `renditionchange` analytics** when video track updates arrive in quick succession (e.g. during seeking).
> 
> In `timedRenditionInfoPublisher`, the async step that loads timing and builds `MUXSDKVideoData` no longer uses plain `flatMap` + `Future`, which could complete work out of upstream order. It now uses the project’s async **`map(priority: .userInitiated)`**, which processes each track emission **sequentially** (`flatMap(maxPublishers: .max(1))`) while keeping the same `.userInitiated` priority.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f13557f557eccef3a541d18ec89821f3cda687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->