### PR TITLE
NAT 494: Avoid missed/reordered events

### DIFF
--- a/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/AudioTrackChangeEvents.swift
@@ -280,14 +280,15 @@ struct AudioTrackChangeEvents {
                         for: AVPlayerItem.mediaSelectionDidChangeNotification,
                         object: playerItem)
                     .map { _ in captureAudioTrackInfo() }
-                    .switchToLatest()
 
                 let audioTrackPublisher = Publishers.Concatenate(
-                    prefix: captureAudioTrackInfo(),
+                    prefix: Just(captureAudioTrackInfo()),
                     suffix: audioTrackChanges)
                     // This can be a very noisy event stream, with intermediate states
                     // reported for fractions of a second.
                     .debounce(for: .seconds(minimumIntervalBetweenEvents), scheduler: DispatchQueue.global())
+                    .buffer(size: 5, prefetch: .keepFull, whenFull: .dropOldest)
+                    .flatMap(maxPublishers: .max(1)) { $0 }
                     .removeDuplicates { a, b in
                         a.trackInfo == b.trackInfo
                     }

--- a/Sources/MUXSDKStatsInternal/Features/TextTrackChangeEvents.swift
+++ b/Sources/MUXSDKStatsInternal/Features/TextTrackChangeEvents.swift
@@ -143,19 +143,20 @@ struct TextTrackChangeEvents {
                         for: AVPlayerItem.mediaSelectionDidChangeNotification,
                         object: playerItem)
                     .map { _ in captureMediaSelectionOption() }
-                    .switchToLatest()
 
                 let mediaSelectionOptionPublisher = Publishers.Concatenate(
-                    prefix: captureMediaSelectionOption(),
+                    prefix: Just(captureMediaSelectionOption()),
                     suffix: mediaSelectionOptionChanges)
                 // This can be a very noisy event stream, with intermediate states reported for fractions of a second:
                     .debounce(for: .seconds(minimumIntervalBetweenEvents), scheduler: DispatchQueue.global())
+                    .buffer(size: 5, prefetch: .keepFull, whenFull: .dropOldest)
+                    .flatMap(maxPublishers: .max(1)) { $0 }
                     .removeDuplicates { a, b in
                         a.selectionInfo == b.selectionInfo
                     }
 
                 return mediaSelectionOptionPublisher
-                    .map { @MainActor selectionOptionAndTiming in
+                    .mapSerial { @MainActor selectionOptionAndTiming in
                         let timing = selectionOptionAndTiming.timing
 
                         guard let selectionOption = selectionOptionAndTiming.selectionInfo else {

--- a/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
+++ b/Sources/MUXSDKStatsInternal/Publishers+AVPlayerItem.swift
@@ -57,7 +57,7 @@ extension AVPlayerItem {
         // playback, during seeking for example. While the following will unique these
         // objects, a new object here may still refer to the same rendition:
             .removeDuplicates()
-            .flatMap { videoAssetTrack in
+            .map { videoAssetTrack in
                 // Boost priority as this kicks off a chain of timing-sensitive operations
                 return Future(priority: .userInitiated) {
                     async let timing = self.currentTiming()
@@ -67,6 +67,8 @@ extension AVPlayerItem {
                     return await (timing, MUXSDKVideoData.makeWithRenditionInfo(track: videoAssetTrack, on: self))
                 }
             }
+            .buffer(size: 5, prefetch: .keepFull, whenFull: .dropOldest)
+            .flatMap(maxPublishers: .max(1)) { $0 }
         // Determine uniqueness (and therefore rendition changes) based on fully populated
         // video data:
             .removeDuplicates { timedInfoA, timedInfoB in

--- a/Sources/MUXSDKStatsInternal/Utilities/Publisher+Extensions.swift
+++ b/Sources/MUXSDKStatsInternal/Utilities/Publisher+Extensions.swift
@@ -4,7 +4,7 @@ import Combine
 extension Publisher {
 
     /// Transforms all elements from the upstream publisher with a provided async closure, waiting for completion before advancing to the next element.
-    func map<T>(isolation: isolated (any Actor)? = #isolation, priority: TaskPriority? = nil, _ transform: @escaping (Self.Output) async -> sending T) -> some Publisher<T, Failure> {
+    func mapSerial<T>(isolation: isolated (any Actor)? = #isolation, priority: TaskPriority? = nil, _ transform: @escaping (Self.Output) async -> sending T) -> some Publisher<T, Failure> {
         flatMap(maxPublishers: .max(1)) { value in
             Future(isolation: isolation, priority: priority) {
                 await transform(value)

--- a/Tests/MUXSDKStatsInternalTests/Utilities/Publisher+ExtensionsTests.swift
+++ b/Tests/MUXSDKStatsInternalTests/Utilities/Publisher+ExtensionsTests.swift
@@ -11,7 +11,7 @@ struct PublisherExtensionsTests {
     @Test func testMapTransformsSingleValue() async throws {
         try await confirmation(expectedCount: 1) { confirmation in
             let values = try await collectOutput(
-                from: Just(1).map { value async in
+                from: Just(1).mapSerial { value async in
                     confirmation()
                     return value * 2
                 }
@@ -24,7 +24,7 @@ struct PublisherExtensionsTests {
     @Test func testMapTransformsMultipleValues() async throws {
         try await confirmation(expectedCount: 3) { confirmation in
             let values = try await collectOutput(
-                from: [1, 2, 3].publisher.map { value async in
+                from: [1, 2, 3].publisher.mapSerial { value async in
                     confirmation()
                     return value * 10
                 }
@@ -36,7 +36,7 @@ struct PublisherExtensionsTests {
     @available(iOS 14, tvOS 14, *)
     @Test func testMapWithAsyncDelayedTransform() async throws {
         let values = try await collectOutput(
-            from: [1, 2, 3].publisher.map { value async in
+            from: [1, 2, 3].publisher.mapSerial { value async in
                 try? await Task.sleep(nanoseconds: UInt64(NSEC_PER_MSEC * 10))
                 return value + 100
             }
@@ -49,7 +49,7 @@ struct PublisherExtensionsTests {
     @available(iOS 14, tvOS 14, *)
     @Test func testMapChangesOutputType() async throws {
         let values = try await collectOutput(
-            from: Just(42).map { value async in
+            from: Just(42).mapSerial { value async in
                 "\(value)"
             }
         )
@@ -62,7 +62,7 @@ struct PublisherExtensionsTests {
     @Test func testMapPreservesSequentialOrder() async throws {
         var order: [Int] = []
         let values = try await collectOutput(
-            from: [1, 2, 3, 4, 5].publisher.map { value async in
+            from: [1, 2, 3, 4, 5].publisher.mapSerial { value async in
                 // Vary delays inversely to ensure ordering
                 // is maintained by serial execution, not speed
                 let delay = UInt64(NSEC_PER_MSEC) * UInt64((6 - value) * 5)
@@ -81,7 +81,7 @@ struct PublisherExtensionsTests {
     @Test func testMapWithEmptyPublisher() async throws {
         try await confirmation(expectedCount: 0) { confirmation in
             let values = try await collectOutput(
-                from: Empty<Int, Never>().map { value async in
+                from: Empty<Int, Never>().mapSerial { value async in
                     confirmation()
                     return "\(value)"
                 }


### PR DESCRIPTION
Fixes a class of bugs with the asynchronous Combine pipelines. At a high level, these pipelines lacked a buffer somewhere. Some asynchronous steps were effectively concurrent, with events reordered by which ones finished processing first. Other pipelines executed the asynchronous step one at a time, but this caused any incoming events to drop.

A small buffer fixes these issues, allowing push-based sources like notifications/observations to pool a few recent values while processing occurs.

Resolves [NAT-494]

[NAT-494]: https://mux1.atlassian.net/browse/NAT-494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event ordering and delivery for playback analytics pipelines; incorrect buffering could still drop or delay track/rendition events, but scope is limited to stats emission rather than playback control.
> 
> **Overview**
> Fixes **missed and out-of-order** MUX stats events when audio, text, and video rendition pipelines process slow async work (MainActor track loads, `Future`s) while notifications keep firing.
> 
> **Audio and text track change publishers** stop using `.switchToLatest()` on `mediaSelectionDidChange` (which dropped in-flight captures), emit the initial snapshot via `Just(...)`, and after debounce add a **size-5 buffer** with **serial** `flatMap(maxPublishers: .max(1))` so a few pending values can wait instead of being lost. Text track mapping switches to **`mapSerial`** for the `@MainActor` async step.
> 
> **Video rendition** (`timedRenditionInfoPublisher`) maps track changes to `Future`s without subscribing concurrently, then applies the same **buffer + serial flatMap** pattern before deduping on populated `MUXSDKVideoData`.
> 
> The shared **`Publisher.map` async helper is renamed to `mapSerial`** (tests updated) to reflect serial, one-at-a-time async transforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99ec254d84d1f7cd6fdd564f9aaadfae60c47dd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->